### PR TITLE
Fix for UserForm and FormDefinition Relation

### DIFF
--- a/cdk/backend/function/createUserformBatch/index.js
+++ b/cdk/backend/function/createUserformBatch/index.js
@@ -437,7 +437,7 @@ async function getUserformByOwnerWithLimit(formDefID = undefined, limit = 1) {
             })
             .promise();
         let lastEvaluatedKey = result.LastEvaluatedKey;
-        while (lastEvaluatedKey) {
+        while (lastEvaluatedKey && !(result.Items.length > 0)) {
             result = await docClient
             .query({
                 TableName: USERFORMTABLE_NAME,
@@ -458,8 +458,6 @@ async function getUserformByOwnerWithLimit(formDefID = undefined, limit = 1) {
                 Limit: limit,
             })
             .promise();
-            if (result.Items.length > 0)
-                break;
             lastEvaluatedKey = result.LastEvaluatedKey;
         }
         console.log("Limited userform querry result: ", result);

--- a/cdk/backend/function/createUserformBatch/index.js
+++ b/cdk/backend/function/createUserformBatch/index.js
@@ -187,7 +187,7 @@ async function getOrCreateUserform(eventInput) {
     };
 
     //Get last userform
-    const lastUserform = await getUserformByOwnerWithLimit();
+    const lastUserform = await getUserformByOwnerWithLimit(eventInput.formDefinitionID);
     if (typeof lastUserform != "undefined" && lastUserform.length > 0) {
         returnValue.oldUserformId = lastUserform[0].id;
         const createdTime = new Date(lastUserform[0].createdAt).getTime();
@@ -375,20 +375,6 @@ async function insertQuestionAnswers(answerArray, userformId) {
         })
         .promise();
     });
-    // for (let i = 0; i < prepedAnswers.length; i++) {
-    //     promises.push(docClient
-    //         .batchWrite(prepedAnswers[i], (err, data) => {
-    //             if (err) {
-    //                 console.log(`BatchWrite error ${i}: `, err);
-    //                 result.failedData.push(err);
-    //                 result.errors.push(err);
-    //             } else {
-    //                 console.log(`BatchWrite data ${i}: `, data);
-    //                 result.data.push(data);
-    //             }
-    //         })
-    //         .promise());
-    // }
     await Promise.all(promises) // Allows us to fire off all writes at the same time?
     return result;
 }
@@ -429,24 +415,53 @@ async function createUserform(formDefinitionId) {
 }
 
 //Returns the X newest userforms by ownerId
-async function getUserformByOwnerWithLimit(limit = 1) {
+async function getUserformByOwnerWithLimit(formDefID = undefined, limit = 1) {
     try {
         let result = await docClient
             .query({
                 TableName: USERFORMTABLE_NAME,
                 IndexName: "byCreatedAt",
                 KeyConditionExpression: "#o = :ownerValue",
+                FilterExpression: "#formdefid = :formdefValue",
                 ExpressionAttributeNames: {
                     "#o": "owner",
+                    "#formdefid": "formDefinitionID"
                 },
                 ExpressionAttributeValues: {
                     ":ownerValue": ownerId,
+                    ":formdefValue": formDefID
                 },
                 ScanIndexForward: false, //Sort direction: true (default) = ASC, false = DESC
                 ConsistentRead: false,
                 Limit: limit,
             })
             .promise();
+        let lastEvaluatedKey = result.LastEvaluatedKey;
+        while (lastEvaluatedKey) {
+            result = await docClient
+            .query({
+                TableName: USERFORMTABLE_NAME,
+                IndexName: "byCreatedAt",
+                KeyConditionExpression: "#o = :ownerValue",
+                FilterExpression: "#formdefid = :formdefValue",  // Make sure we fetch the newest UserForm related to current active form definition
+                ExpressionAttributeNames: {
+                    "#o": "owner",
+                    "#formdefid": "formDefinitionID"
+                },
+                ExpressionAttributeValues: {
+                    ":ownerValue": ownerId,
+                    ":formdefValue": formDefID
+                },
+                ExclusiveStartKey: lastEvaluatedKey,
+                ScanIndexForward: false, //Sort direction: true (default) = ASC, false = DESC
+                ConsistentRead: false,
+                Limit: limit,
+            })
+            .promise();
+            if (result.Items.length > 0)
+                break;
+            lastEvaluatedKey = result.LastEvaluatedKey;
+        }
         console.log("Limited userform querry result: ", result);
         return result.Items;
     } catch (err) {

--- a/cdk/hooks/hooks.ts
+++ b/cdk/hooks/hooks.ts
@@ -5,13 +5,12 @@ const file = fs.readFileSync("outputs.json", {encoding: "utf-8"})
 
 const json = JSON.parse(file);
 let stack: any;
-// const stack = json.KompetanseStack;
+
 stack = json[Object.keys(json)[0]];
-// console.log(stack);
+
 stack.oauth = JSON.parse(stack.oauth);
 stack.functionMap = JSON.parse(stack.functionMap);
 const functionMap = Object.keys(stack.functionMap).map(key => {
-    // stack.functionMap[key].endpoint = stack.functionMap[key].endpoint.substring(0, stack.functionMap[key].endpoint.length - 1) 
     return {
         ...stack.functionMap[key],
         endpoint: stack.functionMap[key].endpoint.substring(0, stack.functionMap[key].endpoint.length - 1) // Remove / from endpoint 

--- a/cdk/lib/kompetanse-stack.ts
+++ b/cdk/lib/kompetanse-stack.ts
@@ -109,17 +109,6 @@ export class KompetanseStack extends Stack {
         ),
       });
 
-      // authRole.addToPolicy(new iam.PolicyStatement({
-      //   actions: [
-      //     "execute-api:Invoke"
-      //   ],
-      //   resources: [
-      //     "arn:aws:execute-api:eu-central-1:153690382195:65iwvl3jha/migrate/GET//*",
-      //     "arn:aws:execute-api:eu-central-1:153690382195:65iwvl3jha/migrate/GET/"
-      //   ],
-      //   effect: iam.Effect.ALLOW
-      // }))
-
       const unauthRole = new iam.Role(this, "UnauthRole", {
         assumedBy: new iam.FederatedPrincipal(
           "cognito-identity.amazonaws.com",
@@ -179,19 +168,6 @@ export class KompetanseStack extends Stack {
 
     const domainSettings: { cognitoDomain?: { domainPrefix: string }, customDomain?: { domainName: string, certificate: cam.Certificate } } = {}
     if (isProd) {
-      // const hostedZone = new r53.HostedZone(this, "KompetansekartleggingHostedZone", {
-      //   zoneName: "kompetanse.knowit.no",
-      // });
-
-      // const authDomainName = "auth.kompetanse.knowit.no";
-      // const certificate = new cam.Certificate(this, "auth.kompetanse.knowit.no", {
-      //   domainName: authDomainName,
-      //   validation: cam.CertificateValidation.fromDns(hostedZone)
-      // });
-      // domainSettings.customDomain = {
-      //     domainName: authDomainName,
-      //     certificate: certificate
-      // };
       domainSettings.cognitoDomain = {
         domainPrefix: `komptest-${ENV}`
       };
@@ -605,8 +581,6 @@ export class KompetanseStack extends Stack {
       }]
     });
   
-
-    // const apiKeyTest = extUsagePlan.addApiKey(new gateway.ApiKey(this, "TestKey", {apiKeyName:"Test"}));
 
     // Backup-plan for production
     if (isProd) {

--- a/frontend-cdk/lib/KompetanseFrontendStack.ts
+++ b/frontend-cdk/lib/KompetanseFrontendStack.ts
@@ -26,8 +26,6 @@ export class KompetanseFrontendStack extends Stack {
       priceClass: cloudfront.PriceClass.PRICE_CLASS_100 // Europe and NA only
     });
 
-    // distribution.addBehavior("", s3Origin, {viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS});
-
     new s3deploy.BucketDeployment(this, 'KompetansekartleggingFrontendBucketDeploy', {
       sources: [s3deploy.Source.asset('../frontend/build')],
       destinationBucket: websiteBucket,

--- a/frontend/src/graphql/custom-queries.ts
+++ b/frontend/src/graphql/custom-queries.ts
@@ -145,7 +145,8 @@ export const customUserFormByCreatedAt = /* GraphQL */ `
         $sortDirection: ModelSortDirection
         $filter: ModelUserFormFilterInput
         $limit: Int
-        $nextToken: String
+        $nextUserFormToken: String
+        $nextQAToken: String
     ) {
         userFormByCreatedAt(
             owner: $owner
@@ -153,11 +154,12 @@ export const customUserFormByCreatedAt = /* GraphQL */ `
             sortDirection: $sortDirection
             filter: $filter
             limit: $limit
+            nextToken: $nextUserFormToken
         ) {
             items {
                 id
                 formDefinitionID
-                questionAnswers(nextToken: $nextToken) {
+                questionAnswers(nextToken: $nextQAToken) {
                     items {
                         id
                         knowledge
@@ -180,6 +182,7 @@ export const customUserFormByCreatedAt = /* GraphQL */ `
                     nextToken
                 }
             }
+            nextToken
         }
     }
 `;


### PR DESCRIPTION
Current behaviour in front-end is to fetch the latest UserForm connected to user, with no regard for which formdefinition it is connected to. This patch makes the frontend fetch latest UserForm connected to current Formdefinition instead of just the latest UserForm.

This patch also fixes the same issue in the creation of UserForms, where it fetched the latest UserForm, and not the latest UserForm tied to the given FormDefinition. This made a users answers disappear when copies of a Form Definitions were made.

Removes unnecessary commented code