### PR TITLE
Hotfix menu scroll

### DIFF
--- a/frontend/src/components/Content.tsx
+++ b/frontend/src/components/Content.tsx
@@ -84,7 +84,7 @@ const contentStyle = makeStyles({
         width: "100%",
         display: "flex",
         flexDirection: "row",
-        overflow: "hidden",
+        overflow: "scroll",
     },
     menu: {
         background: KnowitColors.beige,


### PR DESCRIPTION
Hotfix for resolving issue regarding menu component

issue:
If the catalogue contains too many categories, then the menu is not scrollable.
Added scroll back to main component.  

This does lead to double scroll effect for questions, better styling for this to come