### PR TITLE
Cloudwatch alarm on createUserFormBatch timeout

### DIFF
--- a/cdk/lib/kompetanse-stack.ts
+++ b/cdk/lib/kompetanse-stack.ts
@@ -488,12 +488,12 @@ export class KompetanseStack extends Stack {
       alarmDescription: `Alarm when lambda createUserFormBatch times out (${batchCreateUserTimeoutSeconds} ${batchCreateUserMetric.unit!.toLowerCase()})`
     });
 
-    const batchCreateUserTopic = new sns.Topic(this, `${ENV}-system-admin-topic`, {
+    const systemAdminTopic = new sns.Topic(this, `${ENV}-system-admin-topic`, {
       displayName: `Kompetansekartlegging ${ENV} systemadministrator`,
       topicName: `${ENV}-system-admin-topic`,
     });
 
-    batchCreateUserAlarm.addAlarmAction(new SnsAction(batchCreateUserTopic));
+    batchCreateUserAlarm.addAlarmAction(new SnsAction(systemAdminTopic));
 
     // Admin API Setup
     

--- a/cdk/lib/kompetanse-stack.ts
+++ b/cdk/lib/kompetanse-stack.ts
@@ -1,4 +1,4 @@
-import { CfnOutput, Duration, Stack, StackProps } from 'aws-cdk-lib';
+import { aws_cloudwatch, CfnOutput, Duration, Stack, StackProps } from 'aws-cdk-lib';
 import * as cam from 'aws-cdk-lib/aws-certificatemanager';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
@@ -7,6 +7,10 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as backup from 'aws-cdk-lib/aws-backup';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb'
 import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as sns from 'aws-cdk-lib/aws-sns'
+import * as subscription from 'aws-cdk-lib/aws-sns-subscriptions';
+import { ComparisonOperator, Statistic, TreatMissingData, Unit } from 'aws-cdk-lib/aws-cloudwatch';
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 // import * as appsync from 'aws-cdk-lib/aws-appsync';
 import * as gateway from 'aws-cdk-lib/aws-apigateway';
 // import { CfnUserPoolIdentityProvider } from 'aws-cdk-lib/aws-cognito';
@@ -458,15 +462,45 @@ export class KompetanseStack extends Stack {
 
     // CreateUserFormBatch Setup
 
+    const batchCreateUserTimeoutSeconds = 25;
     const batchCreateUser = new lambda.Function(this, "kompetansebatchuserform", {
       code: lambda.Code.fromAsset(path.join(__dirname, "/../backend/function/createUserformBatch")),
       handler: "index.handler",
       runtime: lambda.Runtime.NODEJS_14_X,
-      timeout: Duration.seconds(25)
+      timeout: Duration.seconds(batchCreateUserTimeoutSeconds)
     });
     appSync.addLambdaDataSourceAndResolvers("createUserformBatch", "BatchCreateUserDataSource", batchCreateUser);
     
     if (batchCreateUser.role) createUserFormPolicy.attachToRole(batchCreateUser.role);
+
+    if (["dev", "prod", "sandboxrebner"].includes(ENV)) { // TODO: fjern sandboxrebner
+      const batchCreateUserMetric: aws_cloudwatch.Metric = batchCreateUser.metricDuration({
+        statistic: Statistic.MAXIMUM,
+        period: Duration.minutes(1), // TODO: 5
+        unit: Unit.MILLISECONDS // TODO: seconds
+      });
+  
+      const batchCreateUserAlarm = new aws_cloudwatch.Alarm(this, "lambda-createUserFormBatch-timeout-alarm", {
+        alarmName: `${ENV}-lambda-createUserFormBatch-timeout-alarm`,
+        metric: batchCreateUserMetric,
+        threshold: 5, // TODO: batchCreateUserTimeoutSeconds
+        comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+        evaluationPeriods: 1,
+        alarmDescription: `Alarm when lambda createUserFormBatch times out (${batchCreateUserTimeoutSeconds} ${batchCreateUserMetric.unit!.toLowerCase()})`
+      });
+  
+      // TODO: potensielt bruke eksisterende "dev-CloudwatchAlarms"-topic?
+      const batchCreateUserTopic = new sns.Topic(this, "topic", {
+        displayName: "Kompetansekartlegging system admin",
+        topicName: "system-admin-subscription-topic",
+      });
+
+      batchCreateUserTopic.addSubscription(
+        new subscription.EmailSubscription("email@email.no"));
+  
+      batchCreateUserAlarm.addAlarmAction(new SnsAction(batchCreateUserTopic));
+    }
     
     // Admin API Setup
     

--- a/cdk/lib/kompetanse-stack.ts
+++ b/cdk/lib/kompetanse-stack.ts
@@ -472,7 +472,7 @@ export class KompetanseStack extends Stack {
     
     if (batchCreateUser.role) createUserFormPolicy.attachToRole(batchCreateUser.role);
 
-    const batchCreateUserMetric: aws_cloudwatch.Metric = batchCreateUser.metricDuration({
+    const batchCreateUserMetric = batchCreateUser.metricDuration({
       statistic: Statistic.MAXIMUM,
       period: Duration.minutes(5),
       unit: Unit.SECONDS


### PR DESCRIPTION
Kode som setter opp metric, alarm og topic. Alarm trigges når lambdaen `createUserFormBatch` timer ut, og melding sendes på det nye topicet `{env}-system-admin-topic`.

Droppet å sette opp subscriptions her for å unngå hardkodede e-poster i public repo, og varsler fra sandboxes.
Tenker at varsling på e-post og i slack-kanalen `#dataplattform-aws-alarms` kan settes opp i AWS-konsollen.

closes #39 