### PR TITLE
Choose form to download Excel report from

### DIFF
--- a/cdk/backend/function/excelGenerator/index.py
+++ b/cdk/backend/function/excelGenerator/index.py
@@ -83,7 +83,8 @@ def fetch_user_answers(username, formDef):
     return {"username": username, "userFormId": currentUserForm["id"], "answers": answers}
 
 
-async def fetch_org_data(orgid):
+async def fetch_org_data(orgid, formDefId):
+    """
     later = datetime.now()
     formDefsResponse = db_client.query(
             TableName=formDefTable,
@@ -101,12 +102,13 @@ async def fetch_org_data(orgid):
 
     currentFormDef = formDefs[-1]["id"]
     print("Time passed fetching form defs:", datetime.now() - later)
+    """
     later = datetime.now()
     catResponse = db_client.query(
         TableName=categoryTable,
         IndexName="byFormDefinition",
         KeyConditionExpression="formDefinitionID = :formDef",
-        ExpressionAttributeValues={":formDef": {"S": currentFormDef}},
+        ExpressionAttributeValues={":formDef": {"S": formDefId}} #currentFormDef}},
     )
 
     categories = []
@@ -123,7 +125,7 @@ async def fetch_org_data(orgid):
         IndexName="byFormDefinition",
         Select="ALL_ATTRIBUTES",
         KeyConditionExpression="formDefinitionID = :formDef",
-        ExpressionAttributeValues={":formDef": {"S": currentFormDef}},
+        ExpressionAttributeValues={":formDef": {"S": formDefId}} #currentFormDef}},
     )
 
     questions = []
@@ -174,7 +176,7 @@ async def fetch_org_data(orgid):
     # with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
 
     for user in users:
-        userAnswers = asyncio.to_thread(fetch_user_answers, user["Username"], currentFormDef)
+        userAnswers = asyncio.to_thread(fetch_user_answers, user["Username"], formDefId) #currentFormDef)
         answerTasks.append(userAnswers)
 
     answers = await asyncio.gather(*answerTasks)
@@ -185,12 +187,15 @@ async def fetch_org_data(orgid):
     
     print("Time passed fetching answers:", datetime.now() - later)
 
-    return formDefs, categories, questions, mappedUsers
+    #return formDefs, categories, questions, mappedUsers
+    return categories, questions, mappedUsers
 
 def handler(event, context):
     print(event)
     later = datetime.now()
     groups = event["requestContext"]["authorizer"]["claims"]["cognito:groups"].split(",")
+    formDefId = event["queryStringParameters"]["formDefId"]
+    formDefLabel = event["queryStringParameters"]["formDefLabel"]
     isAdmin = False
     orgid = ""
     print("Hello", groups)
@@ -203,14 +208,14 @@ def handler(event, context):
 
     if isAdmin:
         print("User is admin")
-        book = asyncio.run(make_workbook(orgid))
+        book = asyncio.run(make_workbook(orgid, formDefId))
         print("Time passed make_workbook:", datetime.now() - later)
         with NamedTemporaryFile(mode="w+b") as temp:
             book.save(temp.name)
             temp.seek(0)
             print("Time passed save workbook:", datetime.now() - later)
             # stream = temp.read()
-            key = f"{orgid}_report_{datetime.now().isoformat(sep='-',timespec='minutes')}.xlsx"
+            key = f"{orgid}_{formDefLabel}_report_{datetime.now().isoformat(sep='-',timespec='minutes')}.xlsx"
             s3_client.put_object(Bucket=bucketName, Key=key, Body=temp)
             presigned_url = s3_client.generate_presigned_url('get_object',
                                                         Params={'Bucket': bucketName,
@@ -282,9 +287,10 @@ def add_user_row(data_sheet, aggregateSheet, row, user, questions, questionPosit
         catCol += len(questionCategoryMap[category["id"]])
         aggCol += 4
 
-async def make_workbook(orgid):
+async def make_workbook(orgid, formDefId):
     later = datetime.now()
-    formDefs, categories, questions, users = await fetch_org_data(orgid)
+    #formDefs, categories, questions, users = await fetch_org_data(orgid, formDefId)
+    categories, questions, users = await fetch_org_data(orgid, formDefId)
     print("Time passed fetching data:", datetime.now() - later)
     later = datetime.now()
     book = Workbook()

--- a/cdk/backend/function/excelGenerator/index.py
+++ b/cdk/backend/function/excelGenerator/index.py
@@ -108,7 +108,7 @@ async def fetch_org_data(orgid, formDefId):
         TableName=categoryTable,
         IndexName="byFormDefinition",
         KeyConditionExpression="formDefinitionID = :formDef",
-        ExpressionAttributeValues={":formDef": {"S": formDefId}} #currentFormDef}},
+        ExpressionAttributeValues={":formDef": {"S": formDefId}}
     )
 
     categories = []
@@ -125,7 +125,7 @@ async def fetch_org_data(orgid, formDefId):
         IndexName="byFormDefinition",
         Select="ALL_ATTRIBUTES",
         KeyConditionExpression="formDefinitionID = :formDef",
-        ExpressionAttributeValues={":formDef": {"S": formDefId}} #currentFormDef}},
+        ExpressionAttributeValues={":formDef": {"S": formDefId}}
     )
 
     questions = []
@@ -176,7 +176,7 @@ async def fetch_org_data(orgid, formDefId):
     # with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
 
     for user in users:
-        userAnswers = asyncio.to_thread(fetch_user_answers, user["Username"], formDefId) #currentFormDef)
+        userAnswers = asyncio.to_thread(fetch_user_answers, user["Username"], formDefId)
         answerTasks.append(userAnswers)
 
     answers = await asyncio.gather(*answerTasks)
@@ -289,7 +289,7 @@ def add_user_row(data_sheet, aggregateSheet, row, user, questions, questionPosit
 
 async def make_workbook(orgid, formDefId):
     later = datetime.now()
-    #formDefs, categories, questions, users = await fetch_org_data(orgid, formDefId)
+    #formDefs, categories, questions, users = await fetch_org_data(orgid)
     categories, questions, users = await fetch_org_data(orgid, formDefId)
     print("Time passed fetching data:", datetime.now() - later)
     later = datetime.now()

--- a/frontend/src/components/AdminPanel/AdminMenu.tsx
+++ b/frontend/src/components/AdminPanel/AdminMenu.tsx
@@ -34,7 +34,7 @@ const AdminMenu = ({
             text: "Rediger administratorer",
         },
         {
-            text: "Rediger katalog",
+            text: "Rediger kataloger",
             hasInternalRouting: true,
         },
         // refactor this one out once the whole app uses routing

--- a/frontend/src/components/AdminPanel/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel/AdminPanel.tsx
@@ -30,7 +30,7 @@ const activeSubmenuItemToSubmenuCategory = (
             return SubmenuCategory.EDIT_GROUPS;
         case "Rediger administratorer":
             return SubmenuCategory.EDIT_ADMINS;
-        case "Rediger katalog":
+        case "Rediger kataloger":
             return SubmenuCategory.EDIT_CATALOGS;
         case "hidden":
             return SubmenuCategory.HIDDEN;

--- a/frontend/src/components/AdminPanel/DownloadExcelDialog.tsx
+++ b/frontend/src/components/AdminPanel/DownloadExcelDialog.tsx
@@ -132,7 +132,7 @@ return (
                 {formDefinitions.map((formDef: FormDefinition) => (
                     <TableRow key={formDef.id}>
                         <TableCell>{formDef.label}</TableCell>
-                        <TableCell>{new Date(formDef.createdAt).toLocaleString("nb-NO")}</TableCell>
+                        <TableCell>{new Date(formDef.createdAt).toLocaleDateString("nb-NO")}</TableCell>
                         <TableCell align="center">
                             <div style={{height: "5.65rem", display: "flex", alignItems: "center"}}>
                                 {formDef.id == idOfDownloadingForm

--- a/frontend/src/components/AdminPanel/DownloadExcelDialog.tsx
+++ b/frontend/src/components/AdminPanel/DownloadExcelDialog.tsx
@@ -133,7 +133,7 @@ return (
                                 {formDef.id == idOfDownloadingForm
                                     ?   <CircularProgress style={{margin: "0 auto"}}/>
                                     :   <Button
-                                            style={{ margin: "0 auto" }}
+                                            style={{margin: "0 auto"}}
                                             variant="contained"
                                             color="primary"
                                             endIcon={<GetAppIcon/>}

--- a/frontend/src/components/AdminPanel/DownloadExcelDialog.tsx
+++ b/frontend/src/components/AdminPanel/DownloadExcelDialog.tsx
@@ -77,24 +77,29 @@ const DownloadExcelDialog = ({ open, onClose }: any) => {
 
 const DownloadExcelTable = ({formDefinitions} : FormDefinitions) => {
     const [idOfDownloadingForm, setIdOfDownloadingForm] = useState<string>("");
+    const [isExcelError, setIsExcelError] = useState<boolean>(false);
 
     const downloadExcel = async (formDefId: string, formDefLabel: string) => {
+        setIsExcelError(false);
         setIdOfDownloadingForm(formDefId);
-
-        const data = await API.get("CreateExcelAPI", "", {
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `${(await Auth.currentSession())
-                    .getAccessToken()
-                    .getJwtToken()}`
-            },
-            queryStringParameters: {
-                formDefId: `${formDefId}`,
-                formDefLabel: `${formDefLabel}`
-            }
-        });
-        download(data, "report.xlsx");
-        setIdOfDownloadingForm("");
+        try {
+            const data = await API.get("CreateExcelAPI", "", {
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${(await Auth.currentSession())
+                        .getAccessToken()
+                        .getJwtToken()}`
+                },
+                queryStringParameters: {
+                    formDefId: `${formDefId}`,
+                    formDefLabel: `${formDefLabel}`
+                }
+            });
+            download(data, "report.xlsx");
+            setIdOfDownloadingForm("");
+        } catch (e) {
+            setIsExcelError(true);
+        }
     };
 
     const download = (path: string, filename: string) => {
@@ -131,7 +136,12 @@ return (
                         <TableCell align="center">
                             <div style={{height: "5.65rem", display: "flex", alignItems: "center"}}>
                                 {formDef.id == idOfDownloadingForm
-                                    ?   <CircularProgress style={{margin: "0 auto"}}/>
+                                    ?   <>
+                                        {isExcelError
+                                            ? <p style={{ whiteSpace: "pre-wrap", margin: "0 auto" }}>{"Nedlasting feilet.\nEr katalogen tom?"}</p>
+                                            : <CircularProgress style={{margin: "0 auto"}}/>
+                                        }
+                                        </>
                                     :   <Button
                                             style={{margin: "0 auto"}}
                                             variant="contained"

--- a/frontend/src/components/AdminPanel/DownloadExcelDialog.tsx
+++ b/frontend/src/components/AdminPanel/DownloadExcelDialog.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from "react";
+
+import { Box, DialogContent, DialogTitle } from "@material-ui/core";
+import { listAllFormDefinitionsForLoggedInUser } from "./catalogApi";
+import useApiGet from "./useApiGet";
+import { API, Auth } from "aws-amplify";
+
+import Dialog from "@material-ui/core/Dialog";
+import GetAppIcon from '@material-ui/icons/GetApp';
+import CircularProgress from "@material-ui/core/CircularProgress";
+import IconButton from "@material-ui/core/IconButton";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Button from "../mui/Button";
+import Table from "../mui/Table";
+
+import { CloseIcon } from "../DescriptionTable";
+import { dialogStyles } from "../../styles";
+
+type FormDefinition = {
+    id: string
+    label: string
+    createdAt: string
+    updatedAt: string
+}
+
+interface FormDefinitions {
+    formDefinitions: FormDefinition[]
+}
+
+const DownloadExcelDialog = ({ open, onClose }: any) => {
+    const style = dialogStyles();
+    
+    const {
+        result: formDefinitions,
+        error,
+        loading,
+    } = useApiGet({
+        getFn: listAllFormDefinitionsForLoggedInUser
+    })
+
+    return (
+        <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm" PaperProps={{
+            style: { borderRadius: 30 },
+        }}>
+            <DialogTitle>
+                <Box
+                    component="div"
+                    mb={1}
+                    display="flex"
+                    justifyContent="space-between"
+                >
+                    <span className={style.dialogTitleText}>
+                        Last ned resultater
+                    </span>
+                    <IconButton
+                        className={style.closeButton}
+                        onClick={onClose}
+                    >
+                        <CloseIcon />
+                    </IconButton>
+                </Box>
+            </DialogTitle>
+            <DialogContent>
+                {error && <p>An error occured: {error}</p>}
+                {loading && <CircularProgress />}
+                {!error && !loading && formDefinitions && (
+                    <DownloadExcelTable formDefinitions={formDefinitions}/>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+const DownloadExcelTable = ({formDefinitions} : FormDefinitions) => {
+    const [idOfDownloadingForm, setIdOfDownloadingForm] = useState<string>("");
+
+    const downloadExcel = async (formDefId: string, formDefLabel: string) => {
+        setIdOfDownloadingForm(formDefId);
+
+        const data = await API.get("CreateExcelAPI", "", {
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `${(await Auth.currentSession())
+                    .getAccessToken()
+                    .getJwtToken()}`
+            },
+            queryStringParameters: {
+                formDefId: `${formDefId}`,
+                formDefLabel: `${formDefLabel}`
+            }
+        });
+        download(data, "report.xlsx");
+        setIdOfDownloadingForm("");
+    };
+
+    const download = (path: string, filename: string) => {
+        // Create a new link
+        const anchor = document.createElement("a");
+        anchor.href = path;
+        anchor.download = filename;
+
+        // Append to the DOM
+        document.body.appendChild(anchor);
+
+        // Trigger `click` event
+        anchor.click();
+
+        // Remove element from DOM
+        document.body.removeChild(anchor);
+    };
+    
+return (
+    <TableContainer>
+        <Table stickyHeader>
+            <TableHead>
+                <TableRow>
+                    <TableCell>Katalog</TableCell>
+                    <TableCell>Opprettet</TableCell>
+                    <TableCell/>
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {formDefinitions.map((formDef: FormDefinition) => (
+                    <TableRow key={formDef.id}>
+                        <TableCell>{formDef.label}</TableCell>
+                        <TableCell>{new Date(formDef.createdAt).toLocaleString("nb-NO")}</TableCell>
+                        <TableCell align="center">
+                            <div style={{height: "5.65rem", display: "flex", alignItems: "center"}}>
+                                {formDef.id == idOfDownloadingForm
+                                    ?   <CircularProgress style={{margin: "0 auto"}}/>
+                                    :   <Button
+                                            style={{ margin: "0 auto" }}
+                                            variant="contained"
+                                            color="primary"
+                                            endIcon={<GetAppIcon/>}
+                                            onClick={() => {downloadExcel(formDef.id, formDef.label)}}>
+                                            Last ned
+                                        </Button>
+                                }
+                            </div>
+                        </TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    </TableContainer>
+    );
+}
+
+export default DownloadExcelDialog;

--- a/frontend/src/components/AdminPanel/EditAdmins.tsx
+++ b/frontend/src/components/AdminPanel/EditAdmins.tsx
@@ -151,7 +151,7 @@ const DownloadExcelDialog = ({ open, onClose }: any) => {
 const DownloadExcelTable = ({formDefinitions} : FormDefinitions) => {
     const [idOfDownloadingForm, setIdOfDownloadingForm] = useState<string>("");
 
-    const downloadExcel = async (formDefId: string) => {
+    const downloadExcel = async (formDefId: string, formDefLabel: string) => {
         setIdOfDownloadingForm(formDefId);
 
         const data = await API.get("CreateExcelAPI", "", {
@@ -162,7 +162,8 @@ const DownloadExcelTable = ({formDefinitions} : FormDefinitions) => {
                     .getJwtToken()}`
             },
             queryStringParameters: {
-                formDefId: `${formDefId}`
+                formDefId: `${formDefId}`,
+                formDefLabel: `${formDefLabel}`
             }
         });
         download(data, "report.xlsx"); // TODO: more specific filename
@@ -208,7 +209,7 @@ return (
                                             variant="contained"
                                             color="primary"
                                             endIcon={<GetAppIcon/>}
-                                            onClick={() => {downloadExcel(formDef.id)}}>
+                                            onClick={() => {downloadExcel(formDef.id, formDef.label)}}>
                                             Last ned
                                         </Button>
                                 }

--- a/frontend/src/components/AdminPanel/EditAdmins.tsx
+++ b/frontend/src/components/AdminPanel/EditAdmins.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import Container from "@material-ui/core/Container";
 import CircularProgress from "@material-ui/core/CircularProgress";
@@ -39,7 +39,7 @@ import { useSelector } from "react-redux";
 import { selectAdminCognitoGroupName } from "../../redux/User";
 import { API, Auth } from "aws-amplify";
 import exports from "../../exports";
-import { Box, DialogContent, DialogTitle, Modal, Snackbar } from "@material-ui/core";
+import { Box, DialogContent, DialogTitle, Modal } from "@material-ui/core";
 import ReactMarkdown from "react-markdown";
 import { listAllFormDefinitionsForLoggedInUser } from "./catalogApi";
 
@@ -51,20 +51,18 @@ const Admin = (props: any) => {
     const picture = getAttribute(admin, "picture");
 
     return (
-        <>
-            <TableRow>
-                <TableCell>
-                    <PictureAndNameCell name={name} picture={picture} />
-                </TableCell>
-                <TableCell>{email}</TableCell>
-                <TableCell>{username}</TableCell>
-                <TableCell>
-                    <IconButton edge="end" onClick={() => deleteAdmin(admin)}>
-                        <DeleteIcon />
-                    </IconButton>
-                </TableCell>
-            </TableRow>
-        </>
+        <TableRow>
+            <TableCell>
+                <PictureAndNameCell name={name} picture={picture} />
+            </TableCell>
+            <TableCell>{email}</TableCell>
+            <TableCell>{username}</TableCell>
+            <TableCell>
+                <IconButton edge="end" onClick={() => deleteAdmin(admin)}>
+                    <DeleteIcon />
+                </IconButton>
+            </TableCell>
+        </TableRow>
     );
 };
 
@@ -106,28 +104,6 @@ interface FormDefinitions {
 }
 
 const DownloadExcelDialog = ({ open, onClose }: any) => {
-    //const [formDefinitions, setFormDefinitions] = useState<any>(null);
-    //const [isLoading, setIsLoading] = useState<boolean>(true);
-    
-    /*const getFormDefinitions = async () => {
-        const formDefs = await listAllFormDefinitionsForLoggedInUser()
-        .then((response: any) => {
-            //setFormDefinitions(response);
-            setIsLoading(false);
-        });
-    }*/
-    /*useEffect(() => {
-        const getFormDefinitions = async () => {
-            const formDefs = await listAllFormDefinitionsForLoggedInUser()
-            .then((response: any) => {
-                //setFormDefinitions(response);
-                setIsLoading(false);
-            });
-        }
-        
-        getFormDefinitions();
-    }, []);*/
-
     const style = dialogStyles();
     
     const {
@@ -138,10 +114,6 @@ const DownloadExcelDialog = ({ open, onClose }: any) => {
         getFn: listAllFormDefinitionsForLoggedInUser
     })
 
-
-    // TODO: Center CircularProgress
-    // TODO: Flere kolonner? "Opprettet"? "Sist oppdatert"?
-    // TODO: Gi tilbakemelding om at rapporten blir generert
     // TODO: Sjekk sortering
     return (
         <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm" PaperProps={{
@@ -177,13 +149,10 @@ const DownloadExcelDialog = ({ open, onClose }: any) => {
 }
 
 const DownloadExcelTable = ({formDefinitions} : FormDefinitions) => {
-    const [isExcelLoading, setIsExcelLoading] = useState<boolean>(false);
-    const [formDefIdDownloading, setFormDefIdDownloading] = useState<string>("");
+    const [idOfDownloadingForm, setIdOfDownloadingForm] = useState<string>("");
 
     const downloadExcel = async (formDefId: string) => {
-        console.log(formDefId);
-        setIsExcelLoading(true);
-        setFormDefIdDownloading(formDefId);
+        setIdOfDownloadingForm(formDefId);
 
         const data = await API.get("CreateExcelAPI", "", {
             headers: {
@@ -197,8 +166,7 @@ const DownloadExcelTable = ({formDefinitions} : FormDefinitions) => {
             }
         });
         download(data, "report.xlsx"); // TODO: more specific filename
-        setFormDefIdDownloading("");
-        setIsExcelLoading(false);
+        setIdOfDownloadingForm("");
     };
 
     const download = (path: string, filename: string) => {
@@ -216,52 +184,41 @@ const DownloadExcelTable = ({formDefinitions} : FormDefinitions) => {
         // Remove element from DOM
         document.body.removeChild(anchor);
     };
-
+    
 return (
-    <>
     <TableContainer>
         <Table stickyHeader>
             <TableHead>
                 <TableRow>
                     <TableCell>Katalog</TableCell>
                     <TableCell>Opprettet</TableCell>
-                    {/*<TableCell>Sist oppdatert</TableCell>*/}
                     <TableCell/>
                 </TableRow>
             </TableHead>
             <TableBody>
-                {/*isExcelLoading && (
-                    <Snackbar
-                        open={isExcelLoading}
-                        anchorOrigin={{ vertical: "top", horizontal: "center" }}
-                    >
-                        <CircularProgress />
-                    </Snackbar>
-                )*/}
                 {formDefinitions.map((formDef: FormDefinition) => (
                     <TableRow key={formDef.id}>
                         <TableCell>{formDef.label}</TableCell>
                         <TableCell>{new Date(formDef.createdAt).toLocaleString("nb-NO")}</TableCell>
-                        {/*<TableCell>{new Date(formDef.updatedAt).toLocaleString("nb-NO")}</TableCell>*/}
-                        <TableCell>
-                            {(isExcelLoading && formDef.id == formDefIdDownloading) ?
-                                <CircularProgress/>
-                            :
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    endIcon={<GetAppIcon/>}
-                                    onClick={() => {downloadExcel(formDef.id)}}>
-                                    Last ned
-                                </Button>
-                            }
+                        <TableCell align="center">
+                            <div style={{height: "5.65rem", display: "flex", alignItems: "center"}}>
+                                {formDef.id == idOfDownloadingForm
+                                    ?   <CircularProgress style={{margin: "0 auto"}}/>
+                                    :   <Button
+                                            variant="contained"
+                                            color="primary"
+                                            endIcon={<GetAppIcon/>}
+                                            onClick={() => {downloadExcel(formDef.id)}}>
+                                            Last ned
+                                        </Button>
+                                }
+                            </div>
                         </TableCell>
                     </TableRow>
                 ))}
             </TableBody>
         </Table>
     </TableContainer>
-    </>
     );
 }
 

--- a/frontend/src/components/AdminPanel/EditAdmins.tsx
+++ b/frontend/src/components/AdminPanel/EditAdmins.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import Container from "@material-ui/core/Container";
 import CircularProgress from "@material-ui/core/CircularProgress";
@@ -17,7 +17,6 @@ import { CloseIcon } from "../DescriptionTable";
 import PersonAddIcon from "@material-ui/icons/PersonAdd";
 import AssesmentIcon from "@material-ui/icons/BarChart";
 import Typography from "@material-ui/core/Typography";
-
 
 import { dialogStyles } from "../../styles";
 import commonStyles from "./common.module.css";
@@ -114,7 +113,6 @@ const DownloadExcelDialog = ({ open, onClose }: any) => {
         getFn: listAllFormDefinitionsForLoggedInUser
     })
 
-    // TODO: Sjekk sortering
     return (
         <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm" PaperProps={{
             style: { borderRadius: 30 },
@@ -166,7 +164,7 @@ const DownloadExcelTable = ({formDefinitions} : FormDefinitions) => {
                 formDefLabel: `${formDefLabel}`
             }
         });
-        download(data, "report.xlsx"); // TODO: more specific filename
+        download(data, "report.xlsx");
         setIdOfDownloadingForm("");
     };
 
@@ -225,7 +223,6 @@ return (
 
 const EditAdmins = () => {
     const adminCognitoGroupName = useSelector(selectAdminCognitoGroupName);
-    
     const [showDownloadExcel, setShowDownloadExcel] = useState<boolean>(false);
 
     const {
@@ -299,7 +296,7 @@ const EditAdmins = () => {
                         color="primary"
                         startIcon={<AssesmentIcon />}
                         style={{ marginTop: "24px" }}
-                        onClick={() => setShowDownloadExcel(true)/*() => downloadExcel()*/}
+                        onClick={() => setShowDownloadExcel(true)}
                     >
                         Last ned resultater (Excel)
                     </Button>


### PR DESCRIPTION
Knappen "Last ned resultater (Excel)" åpner nå en dialog der man kan velge hvilken katalog man vil laste ned Excel-rapport for. Tilbakemelding under nedlasting gis i form av en CircularProgress-komponent på tabellraden.

Håndterer også feil ved nedlasting av Excel, og gir tilbakemelding.

Endret "Rediger katalog" til "Rediger kataloger" i Admin-undermenyen så det matcher de andre undermenyene.

<img width="811" alt="Screenshot 2023-02-09 at 08 56 08" src="https://user-images.githubusercontent.com/72893130/217751214-2011665b-e260-4fd8-9fe5-c7828244eb15.png">

closes #52 
closes #78 