### PR TITLE
🐛-fix: lastAnsweredAt incorrect

### DIFF
--- a/frontend/src/components/AdminPanel/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel/AdminPanel.tsx
@@ -49,7 +49,7 @@ const AdminPanel = ({ activeSubmenuItem }: AdminPanelProps) => {
                 <EditGroupLeaders />
             )}
             {category === SubmenuCategory.EDIT_ADMINS && <EditAdmins />}
-            {category === SubmenuCategory.EDIT_GROUPS && <EditGroups />}
+            {category === SubmenuCategory.EDIT_GROUPS && <EditGroups showLastAnsweredAt={false}/>}
             {category === SubmenuCategory.EDIT_CATALOGS && (
                 <EditCatalogsRouter />
             )}

--- a/frontend/src/components/AdminPanel/EditGroups.tsx
+++ b/frontend/src/components/AdminPanel/EditGroups.tsx
@@ -69,6 +69,7 @@ const Group = ({
     users,
     open,
     setOpenId,
+    showLastAnsweredAt
 }: any) => {
     const hasGroupLeader = !!group.groupLeader;
     const name = hasGroupLeader
@@ -130,6 +131,7 @@ const Group = ({
                                 deleteMember={(user: any) =>
                                     deleteMember(user, group.id)
                                 }
+                                showLastAnsweredAt={showLastAnsweredAt}
                             />
                         </Box>
                     </Collapse>
@@ -148,6 +150,7 @@ const GroupsTable = ({
     editGroup,
     addMembersToGroup,
     deleteMember,
+    showLastAnsweredAt
 }: any) => {
     const [openId, setOpenId] = useState<string>("");
     const setOpenGroup = (groupId: string) => {
@@ -198,6 +201,7 @@ const GroupsTable = ({
                             addMembersToGroup={addMembersToGroup}
                             deleteMember={deleteMember}
                             editGroup={editGroup}
+                            showLastAnsweredAt={showLastAnsweredAt}
                         />
                     ))}
                 </TableBody>
@@ -206,7 +210,7 @@ const GroupsTable = ({
     );
 };
 
-const EditGroups = () => {
+const EditGroups = ({ showLastAnsweredAt }: any) => {
     const userState = useAppSelector(selectUserState);
 
     const {
@@ -316,7 +320,9 @@ const EditGroups = () => {
         refreshAllUsers();
     };
 
-    const [lastAnsweredAtLoading, setLastAnsweredAtLoading] = useState<boolean>(true);
+    const [lastAnsweredAtLoading, setLastAnsweredAtLoading] =
+        useState<boolean>(showLastAnsweredAt);
+
     const isLoading =
         loading ||
         allAvailableUsersLoading ||
@@ -366,13 +372,13 @@ const EditGroups = () => {
                     return u;
                 }
             });
-            if (formDefinitions.length > 0) {
+            if (showLastAnsweredAt && formDefinitions.length > 0) {
                 addLastAnsweredAt(annotated);
             } else {
                 setAllAvailableUsersAnnotated(annotated);
             }
         }
-    }, [allAvailableUsers, formDefinitions, groupLeaders, groups, users])
+    }, [allAvailableUsers, formDefinitions, groupLeaders, groups, users, showLastAnsweredAt]);
 
     return (
         <Container maxWidth="md" className={commonStyles.container}>
@@ -400,6 +406,7 @@ const EditGroups = () => {
                         addMembersToGroup={addMembersToGroup}
                         deleteMember={deleteMember}
                         editGroup={editGroup}
+                        showLastAnsweredAt={showLastAnsweredAt}
                     />
                     <Button
                         variant="contained"

--- a/frontend/src/components/AdminPanel/GroupMembers.tsx
+++ b/frontend/src/components/AdminPanel/GroupMembers.tsx
@@ -13,11 +13,14 @@ import Button from "../mui/Button";
 import Table from "../mui/Table";
 import TableRow from "../mui/TableRow";
 
-const User = ({ user, deleteMember, viewMember }: any) => {
+const User = ({ user, deleteMember, viewMember, showLastAnsweredAt }: any) => {
     const name = getAttribute(user, "name");
     const email = getAttribute(user, "email");
-    //const formLastAnsweredAt = user.lastAnsweredAt == null ? "Ikke besvart" : new Date(user.lastAnsweredAt).toLocaleDateString("nb-NO");
     const picture = getAttribute(user, "picture");
+    const formLastAnsweredAt = user.lastAnsweredAt == null
+        ? "Ikke besvart"
+        : user.lastAnsweredAt.toLocaleDateString("nb-NO");
+
     const onClick = () => {
         if (viewMember) viewMember(user.Username);
     };
@@ -28,7 +31,7 @@ const User = ({ user, deleteMember, viewMember }: any) => {
                 <PictureAndNameCell name={name} picture={picture} />
             </TableCell>
             <TableCell onClick={onClick}>{email}</TableCell>
-            {/*<TableCell>{formLastAnsweredAt}</TableCell>*/}
+            {showLastAnsweredAt && <TableCell>{formLastAnsweredAt}</TableCell>}
             <TableCell>
                 <Button
                     onClick={() => deleteMember(user)}
@@ -47,6 +50,7 @@ const GroupMembers = ({
     addMembersToGroup,
     deleteMember,
     viewMember,
+    showLastAnsweredAt
 }: any) => {
     const [open, setOpen] = useState<boolean>(false);
     const onConfirm = (users: any[]) => {
@@ -62,7 +66,7 @@ const GroupMembers = ({
                         <TableRow>
                             <TableCell>Ansatt</TableCell>
                             <TableCell>Email</TableCell>
-                            {/*<TableCell>Sist besvart</TableCell>*/}
+                            {showLastAnsweredAt && <TableCell>Sist besvart</TableCell>}
                             <TableCell />
                         </TableRow>
                     </TableHead>
@@ -73,6 +77,7 @@ const GroupMembers = ({
                                 user={u}
                                 deleteMember={deleteMember}
                                 viewMember={viewMember}
+                                showLastAnsweredAt={showLastAnsweredAt}
                             />
                         ))}
                     </TableBody>

--- a/frontend/src/components/GroupLeaderPanel/Main.tsx
+++ b/frontend/src/components/GroupLeaderPanel/Main.tsx
@@ -49,6 +49,7 @@ const Main = ({
                             deleteMember(user, groupId)
                         }
                         viewMember={viewMember}
+                        showLastAnsweredAt={true}
                     />
                 </>
             )}


### PR DESCRIPTION
`lastAnsweredAt` ble `null` for noen brukere selv om de hadde svart på katalogen.

Årsaken var uforventet query-respons (en tom liste og `nextToken`).
Dette ble feilaktig tolket som at brukeren ikke har svart.
Løsningen var å hente resterende data i do/while-løkke helt til `nextToken` blir `null`.

Å se dato for siste besvarelse i admin-fanen "Rediger grupper" er nå disablet med en boolean, fordi det utgjør svært mange kall for å finne frem til siste besvarelse for hver eneste bruker.

closes #31 