### PR TITLE
Frontend-endring på endring av eksisterende spørsmål

### DIFF
--- a/frontend/src/components/AdminPanel/EditCatalogs/QuestionListItemEdit.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/QuestionListItemEdit.tsx
@@ -55,11 +55,13 @@ const useQuestionListStyles = makeStyles(() =>
       marginBottom: '8px',
       '& legend': {
         color: KnowitColors.white,
+        opacity: '38%',
         fontSize: '0.75rem',
       },
       '& span': {
         color: `${KnowitColors.white} !important`,
         fontSize: '0.75rem',
+        opacity: '38%',
         fontWeight: 'normal',
       },
     },


### PR DESCRIPTION
Endre styling av [QuestionListItemEdit.tsx](https://github.com/knowit/kompetansekartlegging-app/blob/main/frontend/src/components/AdminPanel/EditCatalogs/QuestionListItemEdit.tsx) i henhold til [Material ui disabled states](https://m3.material.io/foundations/interaction-states#7b8f7c92-8a1a-45eb-8446-521d6120c7f8).

<img width="387" alt="Screenshot 2023-03-08 at 09 20 01" src="https://user-images.githubusercontent.com/1827289/223662804-3229ae0d-0ae8-4cc9-bdc9-c14a21979653.png">
<img width="383" alt="Screenshot 2023-03-08 at 09 20 05" src="https://user-images.githubusercontent.com/1827289/223662817-823929ca-ad95-4d91-aeea-4c2b36f6e51e.png">

closes #111 