### PR TITLE
Update configure-aws-credentials to v2 #110

### DIFF
--- a/.github/workflows/callable-deploy.yml
+++ b/.github/workflows/callable-deploy.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: "16"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key }}


### PR DESCRIPTION
Endre fra v1 til v2 som bruker Node 16 runtime som default. 

Closes #110 