### PR TITLE
Add `useQuery`

### DIFF
--- a/cdk/backend/function/expressLambda/app.ts
+++ b/cdk/backend/function/expressLambda/app.ts
@@ -46,16 +46,26 @@ export const sqlQuery = async ({
     formatRecordsAs: RecordsFormatType.JSON,
   })
   const response = await rds.send(cmd)
+
+  const status =
+    response.$metadata.httpStatusCode &&
+    response.$metadata.httpStatusCode >= 200 &&
+    response.$metadata.httpStatusCode < 300
+      ? 'ok'
+      : 'unknown'
+
   console.log('🚀 ~ response', response)
   if (response.formattedRecords) {
     const records = JSON.parse(response.formattedRecords)
     if (records.length === 0) {
       return {
+        status,
         message: '🧨 ~ No records returned from the query.',
         data: null,
       }
     }
     return {
+      status,
       message,
       data: records.length === 1 ? records[0] : records,
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@material-ui/icons": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.61",
         "@reduxjs/toolkit": "^1.9.2",
+        "@tanstack/react-query": "^4.26.1",
         "aws-amplify": "^5.0.11",
         "clsx": "^1.2.1",
         "react": "^16.14.0",
@@ -24347,6 +24348,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.26.1.tgz",
+      "integrity": "sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.26.1.tgz",
+      "integrity": "sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg==",
+      "dependencies": {
+        "@tanstack/query-core": "4.26.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tootallnate/once": {
@@ -66928,6 +66964,20 @@
         "@svgr/plugin-jsx": "^5.5.0",
         "@svgr/plugin-svgo": "^5.5.0",
         "loader-utils": "^2.0.0"
+      }
+    },
+    "@tanstack/query-core": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.26.1.tgz",
+      "integrity": "sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.26.1.tgz",
+      "integrity": "sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg==",
+      "requires": {
+        "@tanstack/query-core": "4.26.1",
+        "use-sync-external-store": "^1.2.0"
       }
     },
     "@tootallnate/once": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@reduxjs/toolkit": "^1.9.2",
+    "@tanstack/react-query": "^4.26.1",
     "aws-amplify": "^5.0.11",
     "clsx": "^1.2.1",
     "react": "^16.14.0",
@@ -82,11 +83,11 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/recharts": "^1.8.24",
     "@types/uuid": "^9.0.0",
-    "eslint": "^7.32.0",
-    "prettier": "^2.8.3",
-    "typescript": "^4.9.4",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
+    "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.6.0",
-    "eslint-plugin-prettier": "^4.2.1"
+    "eslint-plugin-prettier": "^4.2.1",
+    "prettier": "^2.8.3",
+    "typescript": "^4.9.4"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,24 +1,25 @@
-import React, { Fragment, useEffect, useRef, useState } from 'react'
-import './App.css'
 import { API, Auth, Hub } from 'aws-amplify'
+import { Fragment, useEffect, useRef, useState } from 'react'
+import './App.css'
 // import awsconfig from "./aws-exports";
-import awsconfig from './exports'
-import Content from './components/Content'
-import Login from './components/Login'
-import { ThemeProvider } from '@material-ui/core/styles'
+import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth'
 import { Button, debounce, makeStyles, Snackbar } from '@material-ui/core'
+import { ThemeProvider } from '@material-ui/core/styles'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { isMobile } from 'react-device-detect'
+import Content from './components/Content'
 import FloatingScaleDescButton from './components/FloatingScaleDescButton'
+import Login from './components/Login'
 import NavBarDesktop from './components/NavBarDesktop'
-import theme from './theme'
+import awsconfig from './exports'
+import { useAppDispatch, useAppSelector } from './redux/hooks'
 import {
+  fetchOrganizationNameByID,
+  selectUserState,
   setUserInfo,
   setUserInfoLogOut,
-  selectUserState,
-  fetchOrganizationNameByID,
 } from './redux/User'
-import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth'
-import { useAppSelector, useAppDispatch } from './redux/hooks'
+import theme from './theme'
 
 const userBranch = process ? process.env.REACT_APP_USER_BRANCH : '' // Process does not exist in Webpack 5?
 
@@ -80,6 +81,8 @@ const appStyle = makeStyles({
 const cognitoUserContainsAttributes = (data: any): boolean => {
   return 'attributes' in data
 }
+
+const queryClient = new QueryClient()
 
 const App = () => {
   const dispatch = useAppDispatch()
@@ -194,63 +197,65 @@ const App = () => {
   const [bannerOpen, setBannerOpen] = useState(true)
 
   return (
-    <ThemeProvider theme={theme}>
-      <div className={style.root}>
-        {userBranch !== 'master' ? (
-          <Snackbar
-            open={bannerOpen}
-            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-          >
-            <div
-              style={{
-                background: 'rgba(0,255,0, 255)',
-                borderRadius: 5,
-                padding: 4,
-                textAlign: 'center',
-              }}
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <div className={style.root}>
+          {userBranch !== 'master' ? (
+            <Snackbar
+              open={bannerOpen}
+              anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
             >
-              NB: Dette er et test miljø!{' '}
-              <Button onClick={() => setBannerOpen(false)}>Close</Button>
-            </div>
-          </Snackbar>
-        ) : null}
-        {userState.isSignedIn ? (
-          <Fragment>
-            {isMobile ? null : (
-              <NavBarDesktop
-                displayAnswers={displayAnswers}
-                signout={signout}
-              />
-            )}
+              <div
+                style={{
+                  background: 'rgba(0,255,0, 255)',
+                  borderRadius: 5,
+                  padding: 4,
+                  textAlign: 'center',
+                }}
+              >
+                NB: Dette er et test miljø!{' '}
+                <Button onClick={() => setBannerOpen(false)}>Close</Button>
+              </div>
+            </Snackbar>
+          ) : null}
+          {userState.isSignedIn ? (
+            <Fragment>
+              {isMobile ? null : (
+                <NavBarDesktop
+                  displayAnswers={displayAnswers}
+                  signout={signout}
+                />
+              )}
 
-            <Content
-              setAnswerHistoryOpen={setAnswerHistoryOpen}
-              answerHistoryOpen={answerHistoryOpen}
-              isMobile={isMobile}
-              signout={signout}
-              collapseMobileCategories={collapseMobileCategories}
-              categoryNavRef={categoryNavRef}
-              mobileNavRef={mobileNavRef}
-              scrollToTop={scrollToTopMobile}
-              setCollapseMobileCategories={setCollapseMobileCategories}
-              setScaleDescOpen={setScaleDescOpen}
-              setFirstTimeLogin={setFirstTimeLogin}
-              setShowFab={setShowFab}
-            />
-            {showFab && (
-              <FloatingScaleDescButton
-                scaleDescOpen={scaleDescOpen}
-                setScaleDescOpen={setScaleDescOpen}
-                firstTimeLogin={firstTimeLogin}
+              <Content
+                setAnswerHistoryOpen={setAnswerHistoryOpen}
+                answerHistoryOpen={answerHistoryOpen}
                 isMobile={isMobile}
+                signout={signout}
+                collapseMobileCategories={collapseMobileCategories}
+                categoryNavRef={categoryNavRef}
+                mobileNavRef={mobileNavRef}
+                scrollToTop={scrollToTopMobile}
+                setCollapseMobileCategories={setCollapseMobileCategories}
+                setScaleDescOpen={setScaleDescOpen}
+                setFirstTimeLogin={setFirstTimeLogin}
+                setShowFab={setShowFab}
               />
-            )}
-          </Fragment>
-        ) : (
-          <Login isMobile={isMobile} />
-        )}
-      </div>
-    </ThemeProvider>
+              {showFab && (
+                <FloatingScaleDescButton
+                  scaleDescOpen={scaleDescOpen}
+                  setScaleDescOpen={setScaleDescOpen}
+                  firstTimeLogin={firstTimeLogin}
+                  isMobile={isMobile}
+                />
+              )}
+            </Fragment>
+          ) : (
+            <Login isMobile={isMobile} />
+          )}
+        </div>
+      </ThemeProvider>
+    </QueryClientProvider>
   )
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,6 +5,7 @@ import { API, Auth } from 'aws-amplify'
 const API_NAME = 'ExpressLambda'
 
 interface ApiResponse<T> {
+  status: 'ok' | 'unknown'
   message: string
   data: T | null
 }
@@ -27,32 +28,34 @@ export const apiGET = async <T>(
   path: string,
   params?: { queryStringParameters?: QSParameters }
 ): Promise<ApiResponse<T>> => {
-  try {
-    const init = await createMyInit()
-    return await API.get(API_NAME, `/api${path}`, {
-      ...init,
-      ...params,
-    })
-  } catch (error) {
-    console.error('error', error)
-    throw error
+  const init = await createMyInit()
+  const res = await API.get(API_NAME, `/api${path}`, {
+    ...init,
+    ...params,
+  })
+
+  if (res.status !== 'ok') {
+    throw new Error(`Error! HTTPS status is ${res.status}!`)
   }
+
+  return res
 }
 
 export const apiPOST = async <T>(
   path: string,
   params: { queryStringParameters?: QSParameters; body: Body }
 ): Promise<ApiResponse<T>> => {
-  try {
-    const init = await createMyInit()
-    return await API.post(API_NAME, `/api${path}`, {
-      ...init,
-      ...params,
-    })
-  } catch (error) {
-    console.error('error', error)
-    throw error
+  const init = await createMyInit()
+  const res = await API.post(API_NAME, `/api${path}`, {
+    ...init,
+    ...params,
+  })
+
+  if (res.status !== 'ok') {
+    throw new Error(`Error! HTTPS status is ${res.status}!`)
   }
+
+  return res
 }
 
 // ? Det irriterer meg at denne må ha body-params for å fungere, men det er nå sånn så lenge API.del ikke aksepterer queryStringParams
@@ -60,31 +63,32 @@ export const apiDELETE = async <T>(
   path: string,
   params: { body: Body }
 ): Promise<ApiResponse<T>> => {
-  try {
-    const init = await createMyInit()
-    const res = await API.del(API_NAME, `/api${path}`, {
-      ...init,
-      ...params,
-    })
-    return res
-  } catch (error) {
-    console.error('error', error)
-    throw error
+  const init = await createMyInit()
+  const res = await API.del(API_NAME, `/api${path}`, {
+    ...init,
+    ...params,
+  })
+
+  if (res.status !== 'ok') {
+    throw new Error(`Error! HTTPS status is ${res.status}!`)
   }
+
+  return res
 }
 
 export const apiPATCH = async <T>(
   path: string,
   params?: { body?: Body; queryStringParameters: QSParameters }
 ): Promise<ApiResponse<T>> => {
-  try {
-    const init = await createMyInit()
-    return await API.patch(API_NAME, `/api${path}`, {
-      ...init,
-      ...params,
-    })
-  } catch (error) {
-    console.error('error', error)
-    throw error
+  const init = await createMyInit()
+  const res = await API.patch(API_NAME, `/api${path}`, {
+    ...init,
+    ...params,
+  })
+
+  if (res.status !== 'ok') {
+    throw new Error(`Error! HTTPS status is ${res.status}!`)
   }
+
+  return res
 }


### PR DESCRIPTION
I stedet for å bruke hjemmelagde funksjoner som `frontend/src/components/AdminPanel/useApiGet.tsx`, så har jeg lagt til `useQuery`, https://tanstack.com/query/v4/docs/react/overview. 

Har tilpasset endepunktene på backend og responsene frontend for å håndtere error i tillegg. 

Har satt opp `queryClient` og alt, så nå skal man kunne enkelt og greit kalle API-funksjonene mot backenden på følgende vis:
```typescript
const { data, error } = useQuery( { queryKey: [‘minUnikeQueryKey’], queryFn: getAllCatalogs } )
```

`useQuery` tar seg av alt av refetching etc, så bare å lese seg opp på dokumentasjonen for å bruke dens versjon av eventuelle ting vår applikasjon har implementert sånn halvveis fra før.
