### PR TITLE
Actions: Prevents check_files from running on dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ on:
 
 jobs: 
   check_files:
+    if: github.event_name == 'push'
     name: Check if needs deployment
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Hindrer at `check_files` kjører når man trigger deploy-workflow manuelt.
(Ref https://github.com/knowit/kompetansekartlegging-app/actions/runs/4445286016)