### PR TITLE
Increases contrast of LanguageSelect component

### DIFF
--- a/frontend/src/components/LanguageSelect.tsx
+++ b/frontend/src/components/LanguageSelect.tsx
@@ -1,4 +1,4 @@
-import { MenuItem, Select } from '@material-ui/core'
+import { makeStyles, MenuItem, Select } from '@material-ui/core'
 import { useTranslation } from 'react-i18next'
 import { availableLanguages } from '../i18n/i18n'
 import { I18n as amplifyI18n } from 'aws-amplify'
@@ -6,12 +6,29 @@ import LanguageIcon from '@material-ui/icons/Language'
 import { KnowitColors } from '../styles'
 
 type LanguageSelectProps = {
-  iconColor: string
+  color: string
   marginLeft?: number
 }
 
 export const LanguageSelect = (props: LanguageSelectProps) => {
   const { i18n } = useTranslation()
+
+  const classes = makeStyles({
+    select: {
+      '&:before': {
+        borderColor: props.color,
+      },
+      '&:after': {
+        borderColor: props.color,
+      },
+      '&:not(.Mui-disabled):hover::before': {
+        borderColor: props.color,
+      },
+    },
+    arrowIcon: {
+      fill: props.color,
+    },
+  })()
 
   const changeLanguage = (language: string) => {
     i18n.changeLanguage(language)
@@ -21,9 +38,15 @@ export const LanguageSelect = (props: LanguageSelectProps) => {
 
   return (
     <Select
+      className={classes.select}
       value={i18n.language}
+      inputProps={{
+        classes: {
+          icon: classes.arrowIcon,
+        },
+      }}
       onChange={(event) => changeLanguage(event.target.value as string)}
-      renderValue={() => <LanguageIcon style={{ color: props.iconColor }} />}
+      renderValue={() => <LanguageIcon style={{ color: props.color }} />}
       style={{ marginLeft: props.marginLeft }}
       aria-label={
         i18n.t('aria.selectLanguageLanguageIsSelected', {

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -152,7 +152,7 @@ const Login = (props: { isMobile: boolean }) => {
   return showDevLogin ? (
     <>
       <div className={style.languageSelect}>
-        <LanguageSelect iconColor={KnowitColors.darkBrown} />
+        <LanguageSelect color={KnowitColors.darkBrown} />
       </div>
       <Authenticator
         formFields={formFields}
@@ -174,7 +174,7 @@ const Login = (props: { isMobile: boolean }) => {
       </div>
       <div className={style.frontDiv}>
         <div className={style.languageSelect}>
-          <LanguageSelect iconColor={KnowitColors.darkBrown} />
+          <LanguageSelect color={KnowitColors.darkBrown} />
         </div>
         <div className={style.headlineAlign}>
           <h1

--- a/frontend/src/components/NavBarDesktop.tsx
+++ b/frontend/src/components/NavBarDesktop.tsx
@@ -195,7 +195,7 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
           <div className={style.logo}>
             <KnowitLogo />
           </div>
-          <LanguageSelect iconColor={KnowitColors.creme} />
+          <LanguageSelect color={KnowitColors.creme} />
           <h1 className={style.title}>
             {t('navbar.competenceMappingFor')} {userState.organizationName}
           </h1>

--- a/frontend/src/components/NavBarMobile.tsx
+++ b/frontend/src/components/NavBarMobile.tsx
@@ -131,7 +131,7 @@ const NavBarMobile = ({ ...props }: NavBarPropsMobile) => {
       onClick={toggleDrawer(false)}
       onKeyDown={toggleDrawer(false)}
     >
-      <LanguageSelect iconColor={KnowitColors.beige} marginLeft={15} />
+      <LanguageSelect color={KnowitColors.beige} marginLeft={15} />
       <List className={style.list}>
         {props.menuButtons}
         <ListItem className={style.logout} onClick={props.signout}>


### PR DESCRIPTION
Fargesetter språkvelgerens pil-ikon og border så de ikke blender mot mørk navbar-bakgrunn.

Før:
<img width="252" alt="Screenshot 2023-03-22 at 14 52 10" src="https://user-images.githubusercontent.com/72893130/226925560-22106949-865c-4732-8641-62a9d3e9852f.png">  <img width="227" alt="Screenshot 2023-03-22 at 14 55 33" src="https://user-images.githubusercontent.com/72893130/226926530-695a2e1c-ad40-41b6-bbc1-e27312b9bc63.png">


Nå:
<img width="252" alt="Screenshot 2023-03-22 at 14 51 26" src="https://user-images.githubusercontent.com/72893130/226925366-fdbf1bcf-88db-4f09-8013-2ef33f8c0c2a.png">  <img width="222" alt="Screenshot 2023-03-22 at 14 56 35" src="https://user-images.githubusercontent.com/72893130/226926854-b9d89a0e-c835-4aed-aad8-9d5336d4776d.png">

