### PR TITLE
Aligns answer-scales

### DIFF
--- a/frontend/src/components/Question.tsx
+++ b/frontend/src/components/Question.tsx
@@ -36,20 +36,20 @@ const questionStyleDesktop = makeStyles({
     paddingBottom: 10,
   },
   answerArea: {
-    display: 'flex',
-    flexWrap: 'nowrap',
-    justifyContent: 'center',
+    display: 'grid',
+    gridTemplateColumns: 'max-content auto',
+    width: '92%',
+    marginLeft: '4%',
     alignItems: 'center',
   },
   sliderArea: {
-    marginLeft: 30,
-    marginRight: 20,
+    marginLeft: 25,
     padding: 20,
-    width: '75%',
+    width: '90%',
   },
   slider: {
-    marginRight: 15,
-    marginLeft: 15,
+    marginRight: 9,
+    marginLeft: 10,
   },
   iconArea: {
     width: '100%',
@@ -211,41 +211,33 @@ const KnowledgeMotivationSliders = ({
   const { t } = useTranslation()
 
   return (
-    <div>
-      <div className={style.answerArea}>
-        <div className={clsx(style.largeBold)}>
-          {t('competence').toUpperCase()}
-        </div>
-        <div className={style.sliderArea}>
-          <div className={style.iconArea}>
-            {Icon.GetIcons(true, style.icon)}
-          </div>
-          <div className={style.slider}>
-            <Slider
-              value={sliderValues?.knowledge || -2}
-              motivation={false}
-              sliderChanged={sliderChanged}
-              isMobile={isMobile}
-            />
-          </div>
+    <div className={style.answerArea}>
+      <div className={clsx(style.largeBold)}>
+        {t('competence').toUpperCase()}
+      </div>
+      <div className={style.sliderArea}>
+        <div className={style.iconArea}>{Icon.GetIcons(true, style.icon)}</div>
+        <div className={style.slider}>
+          <Slider
+            value={sliderValues?.knowledge || -2}
+            motivation={false}
+            sliderChanged={sliderChanged}
+            isMobile={isMobile}
+          />
         </div>
       </div>
-      <div className={style.answerArea}>
-        <div className={clsx(style.largeBold)}>
-          {t('motivation').toUpperCase()}
-        </div>
-        <div className={style.sliderArea}>
-          <div className={style.iconArea}>
-            {Icon.GetIcons(false, style.icon)}
-          </div>
-          <div className={style.slider}>
-            <Slider
-              value={sliderValues?.motivation || -2}
-              motivation={true}
-              sliderChanged={sliderChanged}
-              isMobile={isMobile}
-            />
-          </div>
+      <div className={clsx(style.largeBold)}>
+        {t('motivation').toUpperCase()}
+      </div>
+      <div className={style.sliderArea}>
+        <div className={style.iconArea}>{Icon.GetIcons(false, style.icon)}</div>
+        <div className={style.slider}>
+          <Slider
+            value={sliderValues?.motivation || -2}
+            motivation={true}
+            sliderChanged={sliderChanged}
+            isMobile={isMobile}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Endrer fra flexbox til grid for å unngå at varierende tekstbredde på "Kompetanse" og "Motivasjon" på ulike språk gjør at svar-skalaene ikke aligner. Tilpasser også slider-margins slik at ikonene havner mer rett over strekene.

Jeg har begrenset CSS-erfaring, så ta gjerne en ekstra titt og arrester meg om jeg har gjort noe rart 👮 

Før:
<img width="419" alt="Screenshot 2023-03-30 at 13 48 24" src="https://user-images.githubusercontent.com/72893130/228826674-dd30aaad-6c2d-4eca-a85b-ebc1ebc88081.png">
Etter:
<img width="419" alt="Screenshot 2023-03-30 at 13 49 06" src="https://user-images.githubusercontent.com/72893130/228826821-6b793f2e-e003-45cc-be8c-e9fff7cf586c.png">


closes #137 