### PR TITLE
Temporarily fixes styling after mui migration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import {
 import { CognitoHostedUIIdentityProvider } from '@aws-amplify/auth'
 import { useAppSelector, useAppDispatch } from './redux/hooks'
 import { useTranslation } from 'react-i18next'
+import { KnowitColors } from './styles'
 
 declare module '@mui/styles/defaultTheme' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -223,7 +224,10 @@ const App = () => {
                 }}
               >
                 {t('thisIsATestEnvironment') + ' '}
-                <Button onClick={() => setBannerOpen(false)}>
+                <Button
+                  onClick={() => setBannerOpen(false)}
+                  style={{ color: KnowitColors.black }}
+                >
                   {t('close').toUpperCase()}
                 </Button>
               </div>

--- a/frontend/src/components/AdminPanel/EditCatalogs/AddCategoryDialog.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/AddCategoryDialog.tsx
@@ -69,6 +69,7 @@ const AddCategoryDialog = ({ onCancel, onConfirm, open }: any) => {
           variant="outlined"
           value={description}
           className={style.textField}
+          style={{ marginRight: 0 }}
           onChange={(e: any) => setDescription(e.target.value)}
         />
       </DialogContent>

--- a/frontend/src/components/AdminPanel/EditCatalogs/AddQuestionDialog.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/AddQuestionDialog.tsx
@@ -15,7 +15,7 @@ import RadioGroup from '@mui/material/RadioGroup'
 import TextField from '@mui/material/TextField'
 
 import { QuestionType } from '../../../API'
-import { dialogStyles } from '../../../styles'
+import { dialogStyles, KnowitColors } from '../../../styles'
 import { CloseIcon } from '../../DescriptionTable'
 import { useTranslation } from 'react-i18next'
 
@@ -114,6 +114,7 @@ const AddQuestionDialog = ({ onCancel, onConfirm, open }: any) => {
           }
           value={description}
           className={style.textField}
+          style={{ marginRight: 0 }}
           onChange={(e: any) => setDescription(e.target.value)}
         />
         <FormControl component="fieldset">

--- a/frontend/src/components/AdminPanel/EditCatalogs/Root.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/Root.tsx
@@ -34,6 +34,7 @@ import AddCatalogDialog from './AddCatalogDialog'
 import { useTranslation } from 'react-i18next'
 import { i18nDateToLocaleString } from '../../../i18n/i18n'
 import CopyCatalogDialog from './CopyCatalogDialog'
+import { KnowitColors } from '../../../styles'
 
 const Catalog = ({
   catalog,
@@ -54,6 +55,7 @@ const Catalog = ({
         </TableCell>
         <TableCell align="right">
           <Button
+            sx={{ color: KnowitColors.black }}
             disabled={active}
             endIcon={<BookmarkIcon />}
             onClick={() => activateCatalog(catalog)}
@@ -68,13 +70,17 @@ const Catalog = ({
               search: `?label=${name}`,
             }}
           >
-            <Button endIcon={<EditIcon />}>
+            <Button endIcon={<EditIcon />} sx={{ color: KnowitColors.black }}>
               {t('admin.editCatalogs.modifyCatalog')}
             </Button>
           </Link>
         </TableCell>
         <TableCell align="right">
-          <Button endIcon={<AddIcon />} onClick={() => copyCatalog(catalog)}>
+          <Button
+            endIcon={<AddIcon />}
+            onClick={() => copyCatalog(catalog)}
+            sx={{ color: KnowitColors.black }}
+          >
             {t('admin.editCatalogs.copyCatalog')}
           </Button>
         </TableCell>
@@ -82,6 +88,7 @@ const Catalog = ({
           <Button
             endIcon={<DeleteIcon />}
             onClick={() => deleteCatalog(catalog)}
+            sx={{ color: KnowitColors.black }}
           >
             {t('admin.editCatalogs.removeCatalog')}
           </Button>

--- a/frontend/src/components/AdminPanel/EditGroups.tsx
+++ b/frontend/src/components/AdminPanel/EditGroups.tsx
@@ -49,6 +49,7 @@ import { compareByCreatedAt, compareByName, getAttribute } from './helpers'
 import PictureAndNameEditCell from './PictureAndNameEditCell'
 import { useTranslation } from 'react-i18next'
 import useApiGet from './useApiGet'
+import { KnowitColors } from '../../styles'
 
 const useRowStyles = makeStyles({
   root: {
@@ -98,7 +99,11 @@ const Group = ({
         </TableCell>
         <TableCell>{group.members.length}</TableCell>
         <TableCell align="right">
-          <Button endIcon={<DeleteIcon />} onClick={() => deleteGroup(group)}>
+          <Button
+            endIcon={<DeleteIcon />}
+            onClick={() => deleteGroup(group)}
+            style={{ color: KnowitColors.black }}
+          >
             {t('admin.editGroups.removeGroup')}
           </Button>
         </TableCell>

--- a/frontend/src/components/AdminPanel/GroupMembers.tsx
+++ b/frontend/src/components/AdminPanel/GroupMembers.tsx
@@ -14,6 +14,7 @@ import { i18nDateToLocaleDateString } from '../../i18n/i18n'
 import AddMemberToGroupDialog from './AddMemberToGroupDialog'
 import { getAttribute } from './helpers'
 import PictureAndNameCell from './PictureAndNameCell'
+import { KnowitColors } from '../../styles'
 
 const User = ({ user, deleteMember, viewMember, showLastAnsweredAt }: any) => {
   const { t } = useTranslation()
@@ -40,7 +41,7 @@ const User = ({ user, deleteMember, viewMember, showLastAnsweredAt }: any) => {
       <TableCell>
         <Button
           onClick={() => deleteMember(user)}
-          style={{ fontStyle: 'italic' }}
+          style={{ fontStyle: 'italic', color: KnowitColors.black }}
         >
           {t('myGroup.removeFromGroup')}
         </Button>

--- a/frontend/src/components/LanguageSelect.tsx
+++ b/frontend/src/components/LanguageSelect.tsx
@@ -16,7 +16,12 @@ export const LanguageSelect = (props: LanguageSelectProps) => {
 
   const classes = makeStyles({
     select: {
-      '&:before': {
+      '& .MuiOutlinedInput-notchedOutline': { border: 0 },
+      borderColor: props.color,
+      borderRadius: 0,
+      borderWidth: 1,
+      height: 35,
+      /*'&:before': {
         borderColor: props.color,
       },
       '&:after': {
@@ -24,7 +29,7 @@ export const LanguageSelect = (props: LanguageSelectProps) => {
       },
       '&:not(.Mui-disabled):hover::before': {
         borderColor: props.color,
-      },
+      },*/
     },
     arrowIcon: {
       fill: props.color,
@@ -39,6 +44,7 @@ export const LanguageSelect = (props: LanguageSelectProps) => {
 
   return (
     <Select
+      sx={{ borderBottom: 2 }}
       className={classes.select}
       value={i18n.language}
       inputProps={{

--- a/frontend/src/components/LanguageSelect.tsx
+++ b/frontend/src/components/LanguageSelect.tsx
@@ -8,6 +8,7 @@ import { KnowitColors } from '../styles'
 
 type LanguageSelectProps = {
   color: string
+  marginTop?: number
   marginLeft?: number
 }
 
@@ -17,19 +18,10 @@ export const LanguageSelect = (props: LanguageSelectProps) => {
   const classes = makeStyles({
     select: {
       '& .MuiOutlinedInput-notchedOutline': { border: 0 },
+      '& .MuiSelect-outlined': { padding: 0 },
       borderColor: props.color,
       borderRadius: 0,
-      borderWidth: 1,
-      height: 35,
-      /*'&:before': {
-        borderColor: props.color,
-      },
-      '&:after': {
-        borderColor: props.color,
-      },
-      '&:not(.Mui-disabled):hover::before': {
-        borderColor: props.color,
-      },*/
+      borderWidth: 1.5,
     },
     arrowIcon: {
       fill: props.color,
@@ -54,7 +46,7 @@ export const LanguageSelect = (props: LanguageSelectProps) => {
       }}
       onChange={(event) => changeLanguage(event.target.value as string)}
       renderValue={() => <LanguageIcon style={{ color: props.color }} />}
-      style={{ marginLeft: props.marginLeft }}
+      style={{ marginTop: props.marginTop, marginLeft: props.marginLeft }}
       aria-label={
         i18n.t('aria.selectLanguageLanguageIsSelected', {
           language: availableLanguages[i18n.language],
@@ -62,7 +54,15 @@ export const LanguageSelect = (props: LanguageSelectProps) => {
       }
     >
       {Object.keys(availableLanguages).map((language) => (
-        <MenuItem key={language} value={language}>
+        <MenuItem
+          key={language}
+          value={language}
+          style={
+            i18n.language == language
+              ? { backgroundColor: '#e4e0dc' }
+              : { backgroundColor: 'transparent' }
+          }
+        >
           <div
             style={{
               fontSize: 14,

--- a/frontend/src/components/NavBarDesktop.tsx
+++ b/frontend/src/components/NavBarDesktop.tsx
@@ -170,7 +170,7 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
     maxHeight: '80%',
     overflowY: 'auto',
     p: 4,
-    borderRadius: 10,
+    //borderRadius: 10,
   }
 
   const [helpMarkdown, setHelpMarkdown] = useState<any>()

--- a/frontend/src/components/NavBarMobile.tsx
+++ b/frontend/src/components/NavBarMobile.tsx
@@ -131,7 +131,11 @@ const NavBarMobile = ({ ...props }: NavBarPropsMobile) => {
       onClick={toggleDrawer(false)}
       onKeyDown={toggleDrawer(false)}
     >
-      <LanguageSelect color={KnowitColors.beige} marginLeft={15} />
+      <LanguageSelect
+        color={KnowitColors.beige}
+        marginTop={12}
+        marginLeft={15}
+      />
       <List className={style.list}>
         {props.menuButtons}
         <ListItem className={style.logout} onClick={props.signout}>

--- a/frontend/src/components/YourAnswersMobile.tsx
+++ b/frontend/src/components/YourAnswersMobile.tsx
@@ -124,6 +124,7 @@ const yourAnswersStyleMobile = makeStyles({
     justifyContent: 'left',
     fontSize: '14px',
     lineHeight: '16px',
+    color: KnowitColors.black,
   },
   yourAnswersMobileContainer: {
     minHeight: '100vh',

--- a/frontend/src/styles.tsx
+++ b/frontend/src/styles.tsx
@@ -59,6 +59,7 @@ export const dialogStyles = makeStyles(
       background: KnowitColors.lightGreen,
       borderRadius: '19px',
       borderColor: KnowitColors.lightGreen,
+      color: KnowitColors.black,
     },
     cancelButton: {
       width: '162px',
@@ -67,6 +68,7 @@ export const dialogStyles = makeStyles(
       borderColor: KnowitColors.flamingo,
       boxsizing: 'border-box',
       borderRadius: '19px',
+      color: KnowitColors.black,
     },
     buttonText: {
       fontWeight: 'bold',
@@ -94,6 +96,12 @@ export const dialogStyles = makeStyles(
     dialogTitleText: {
       fontWeight: 'bold',
       marginTop: '4px',
+    },
+    radio: {
+      radio: {},
+      '&$checked': {
+        color: KnowitColors.black,
+      },
     },
   },
   { index: 1 }

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -1,4 +1,3 @@
-import { grey } from '@mui/material/colors'
 import {
   unstable_createMuiStrictModeTheme as createMuiTheme,
   adaptV4Theme,
@@ -14,7 +13,6 @@ const theme = createMuiTheme(
       secondary: {
         main: KnowitColors.fuchsia,
       },
-      grey: grey,
     },
   })
 )

--- a/frontend/src/theme.tsx
+++ b/frontend/src/theme.tsx
@@ -1,3 +1,4 @@
+import { grey } from '@mui/material/colors'
 import {
   unstable_createMuiStrictModeTheme as createMuiTheme,
   adaptV4Theme,
@@ -13,6 +14,7 @@ const theme = createMuiTheme(
       secondary: {
         main: KnowitColors.fuchsia,
       },
+      grey: grey,
     },
   })
 )


### PR DESCRIPTION
Fikser styling som endret seg etter migrasjon til mui.

Eksempler på hva som ble funky etter migreringen:
- Språkvelger har fått border
<img width="83" alt="Screenshot 2023-03-31 at 10 13 57" src="https://user-images.githubusercontent.com/72893130/229064297-1a40e6ce-520a-4a5f-820d-4d1595b2a0e9.png"> <img width="248" alt="Screenshot 2023-03-31 at 10 13 23" src="https://user-images.githubusercontent.com/72893130/229064161-0ab9345b-ec58-4e56-bb27-e4fc9f27a5c8.png"> <img width="126" alt="Screenshot 2023-03-31 at 10 30 31" src="https://user-images.githubusercontent.com/72893130/229068332-c8e804b2-349f-4889-ac95-60c1c170835c.png">

- Noe har skjedd med knappedesign
<img width="172" alt="Screenshot 2023-03-31 at 10 18 25" src="https://user-images.githubusercontent.com/72893130/229065349-a146f7bb-302c-48a4-be1d-6be8949a9bdc.png"> <img width="428" alt="Screenshot 2023-03-31 at 10 23 01" src="https://user-images.githubusercontent.com/72893130/229066457-d18b7424-fff3-4ddd-999a-96e7345c26b2.png">

- "LUKK" har endret farge - ikke så viktig, men <br><img width="276" alt="Screenshot 2023-03-31 at 10 20 08" src="https://user-images.githubusercontent.com/72893130/229065772-5edf5b12-9da7-4600-a1b4-377b87895f12.png">

- Ved expand av gruppe, admin -> rediger grupper <br><img width="380" alt="Screenshot 2023-03-31 at 10 34 14" src="https://user-images.githubusercontent.com/72893130/229069249-22263942-663d-4925-8237-175eed487b26.png">

- Vakkert  <br><img width="601" alt="Screenshot 2023-03-31 at 10 36 57" src="https://user-images.githubusercontent.com/72893130/229069952-02c3215e-fd37-4bc3-8943-b5d75f5bc173.png">

- Tekstfarge på "Spørsmålstype", selected-farge på radio-button og sudden scrollbar appeared <img width="618" alt="Screenshot 2023-03-31 at 10 41 02" src="https://user-images.githubusercontent.com/72893130/229070991-0e911fd5-2659-4632-a989-dcb1ce974d9b.png">

- "Hjelp"-dialogen har blitt avrundet, scrollbaren går utenfor <br><img width="103" alt="Screenshot 2023-03-31 at 10 44 15" src="https://user-images.githubusercontent.com/72893130/229071785-36ad767c-9112-4e25-9eac-62fbd0c872a8.png"> <img width="63" alt="Screenshot 2023-03-31 at 10 45 52" src="https://user-images.githubusercontent.com/72893130/229072135-bdc61eb8-ecf5-44e7-8cac-9f1142c58b32.png">

