### PR TITLE
Admin email tooltip on AddOrganizationDialog

### DIFF
--- a/frontend/src/components/AdminPanel/DeleteUserFromGroupDialog.tsx
+++ b/frontend/src/components/AdminPanel/DeleteUserFromGroupDialog.tsx
@@ -46,7 +46,7 @@ const DeleteUserFromGroupDialog = ({
       </DialogTitle>
       <DialogContent>
         <DialogContentText>
-          {t('admin.areYouSureYouWantToDeleteNameFromRole', {
+          {t('admin.areYouSureYouWantToRemoveNameFromRole', {
             name: name,
             role: role,
           }) + ' '}

--- a/frontend/src/components/SuperAdminPanel/AddOrganizationDialog.tsx
+++ b/frontend/src/components/SuperAdminPanel/AddOrganizationDialog.tsx
@@ -9,11 +9,12 @@ import DialogTitle from '@material-ui/core/DialogTitle'
 import IconButton from '@material-ui/core/IconButton'
 import TextField from '@material-ui/core/TextField'
 
-import { dialogStyles } from '../../styles'
+import { dialogStyles, KnowitColors } from '../../styles'
 import { CloseIcon } from '../DescriptionTable'
 import { OrganizationInfo } from './SuperAdminTypes'
 import { useTranslation } from 'react-i18next'
-import { CircularProgress } from '@material-ui/core'
+import { CircularProgress, Tooltip } from '@material-ui/core'
+import HelpIcon from '@material-ui/icons/Help'
 
 interface AddOrganizationDialogProps {
   onCancel: () => void
@@ -118,6 +119,21 @@ const AddOrganizationDialog: React.FC<AddOrganizationDialogProps> = ({
           value={organizationAdminEmail}
           className={style.textField}
           onChange={(e: any) => setOrganizationAdminEmail(e.target.value)}
+          InputProps={{
+            endAdornment: (
+              <Tooltip
+                arrow
+                placement="left"
+                title={
+                  <div style={{ fontSize: '1.3em' }}>
+                    {t('superAdmin.editOrganizations.adminEmailTooltip')}
+                  </div>
+                }
+              >
+                <HelpIcon htmlColor={KnowitColors.darkBrown} />
+              </Tooltip>
+            ),
+          }}
         />
       </DialogTitle>
       {isAddingOrganization ? (

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -166,7 +166,7 @@ export const English: LanguageSchema = {
       noGroupLeader: 'No group leader',
     },
     admin: {
-      areYouSureYouWantToDeleteNameFromRole: 'Are you sure you want to delete {{name}} from the {{role}}?',
+      areYouSureYouWantToRemoveNameFromRole: 'Are you sure you want to remove {{name}} from the {{role}}?',
       removeNameFromRole: 'Remove {{name}} from the {{role}}?',
       editGroupLeaders: {
         description: "Group leaders can access their group members' answers. They can also choose their group members. On this page you can add and remove group leaders.",
@@ -253,7 +253,8 @@ export const English: LanguageSchema = {
         addNewOrganization: 'Add new organization',
         idCantBeEmptyOrContainZero: "ID can't be empty or contain '0'.",
         identifierAttributeCantBeEmpty: "Identifier attribute can't be empty.",
-        adminEmailIsInvalid: 'Admin email is invalid.'
+        adminEmailIsInvalid: 'Admin email is invalid.',
+        adminEmailTooltip: 'Empty: Create organization without administrator.\nExisting email: Assign user to the admin role.\nNon-existing email: Create new admin user.',
       },
       editSuperAdministrators: {
         description: 'On this page you can add and remove super-administrators.',

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -166,7 +166,7 @@ export const Norwegian: LanguageSchema = {
       noGroupLeader: 'Mangler gruppeleder',
     },
     admin: {
-      areYouSureYouWantToDeleteNameFromRole: 'Er du sikker på at du har lyst til å fjerne {{name}} fra {{role}}?',
+      areYouSureYouWantToRemoveNameFromRole: 'Er du sikker på at du har lyst til å fjerne {{name}} fra {{role}}?',
       removeNameFromRole: 'Fjern {{name}} fra {{role}}?',
       editGroupLeaders: {
         description: 'Gruppeledere har tilgang til sine egne gruppebarns svar. De kan også velge sine gruppebarn. På denne siden kan du legge til og fjerne gruppeledere.',
@@ -254,6 +254,7 @@ export const Norwegian: LanguageSchema = {
         idCantBeEmptyOrContainZero: "ID kan ikke være tom eller inneholde '0'.",
         identifierAttributeCantBeEmpty: 'Identifier attribute kan ikke være tom.',
         adminEmailIsInvalid: 'Admin e-post er ugyldig.',
+        adminEmailTooltip: 'Tom: Opprett organisasjon uten administrator.\nEksisterende e-post: Tildel bruker admin-rollen.\nIkke-eksisterende e-post: Lag ny admin-bruker.',
       },
       editSuperAdministrators: {
         description: 'På denne siden kan du legge til og fjerne super-administratorer.',

--- a/frontend/src/i18n/schema.ts
+++ b/frontend/src/i18n/schema.ts
@@ -164,7 +164,7 @@ export type LanguageSchema = {
       noGroupLeader: string
     }
     admin: {
-      areYouSureYouWantToDeleteNameFromRole: string
+      areYouSureYouWantToRemoveNameFromRole: string
       removeNameFromRole: string
       editGroupLeaders: {
         description: string
@@ -252,6 +252,7 @@ export type LanguageSchema = {
         idCantBeEmptyOrContainZero: string
         identifierAttributeCantBeEmpty: string
         adminEmailIsInvalid: string
+        adminEmailTooltip: string
       }
       editSuperAdministrators: {
         description: string


### PR DESCRIPTION
* Tooltip på "Admin Email"-feltet på AddOrganizationDialog

<img width="565" alt="Screenshot 2023-04-14 at 09 45 33" src="https://user-images.githubusercontent.com/72893130/231978735-a285a638-7fb3-491b-87ff-f69de1c9e546.png">
<img width="561" alt="Screenshot 2023-04-14 at 09 46 00" src="https://user-images.githubusercontent.com/72893130/231978822-9c848eef-600c-4e45-81c4-554d1c2dff7c.png">

* Endrer også ordlyd fra "slett x fra gruppe" til "fjern x fra gruppe" på DeleteUserFromGroupDialog
(for å være konsekvent, høres også bedre ut)