### PR TITLE
Replaces 'delete' by 'remove' in DeleteUserFromGroupDialog

### DIFF
--- a/frontend/src/components/AdminPanel/DeleteUserFromGroupDialog.tsx
+++ b/frontend/src/components/AdminPanel/DeleteUserFromGroupDialog.tsx
@@ -46,7 +46,7 @@ const DeleteUserFromGroupDialog = ({
       </DialogTitle>
       <DialogContent>
         <DialogContentText>
-          {t('admin.areYouSureYouWantToDeleteNameFromRole', {
+          {t('admin.areYouSureYouWantToRemoveNameFromRole', {
             name: name,
             role: role,
           }) + ' '}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -166,7 +166,7 @@ export const English: LanguageSchema = {
       noGroupLeader: 'No group leader',
     },
     admin: {
-      areYouSureYouWantToDeleteNameFromRole: 'Are you sure you want to delete {{name}} from the {{role}}?',
+      areYouSureYouWantToRemoveNameFromRole: 'Are you sure you want to remove {{name}} from the {{role}}?',
       removeNameFromRole: 'Remove {{name}} from the {{role}}?',
       editGroupLeaders: {
         description: "Group leaders can access their group members' answers. They can also choose their group members. On this page you can add and remove group leaders.",

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -166,7 +166,7 @@ export const Norwegian: LanguageSchema = {
       noGroupLeader: 'Mangler gruppeleder',
     },
     admin: {
-      areYouSureYouWantToDeleteNameFromRole: 'Er du sikker på at du har lyst til å fjerne {{name}} fra {{role}}?',
+      areYouSureYouWantToRemoveNameFromRole: 'Er du sikker på at du har lyst til å fjerne {{name}} fra {{role}}?',
       removeNameFromRole: 'Fjern {{name}} fra {{role}}?',
       editGroupLeaders: {
         description: 'Gruppeledere har tilgang til sine egne gruppebarns svar. De kan også velge sine gruppebarn. På denne siden kan du legge til og fjerne gruppeledere.',

--- a/frontend/src/i18n/schema.ts
+++ b/frontend/src/i18n/schema.ts
@@ -164,7 +164,7 @@ export type LanguageSchema = {
       noGroupLeader: string
     }
     admin: {
-      areYouSureYouWantToDeleteNameFromRole: string
+      areYouSureYouWantToRemoveNameFromRole: string
       removeNameFromRole: string
       editGroupLeaders: {
         description: string


### PR DESCRIPTION
Endrer ordlyd fra "slett Ola Nordmann fra gruppe" til "fjern Ola Nordmann fra gruppe" på DeleteUserFromGroupDialog.
For å være konsekvent, høres også bedre ut.