### PR TITLE
Finalize superadmin -> edit admins

### DIFF
--- a/cdk/backend/function/AdminQueries/app.js
+++ b/cdk/backend/function/AdminQueries/app.js
@@ -276,6 +276,35 @@ app.get('/listUsersInGroup', async (req, res, next) => {
   }
 })
 
+app.get('/listAllOrganizationAdministrators', async (req, res, next) => {
+  try {
+    let nextToken
+    let allGroups = []
+    do {
+      const res = await listGroups(25, nextToken)
+      allGroups = [...allGroups, ...res.Groups]
+      nextToken = res.NextToken
+    } while (nextToken)
+
+    const orgAdmins = await Promise.all(
+      allGroups.map(async (group) => {
+        if (group.GroupName.includes('0admin')) {
+          return (await listUsersInGroup(group.GroupName)).Users
+        }
+      })
+    )
+
+    // Flatten and remove null values
+    orgAdminsFiltered = orgAdmins
+      .flat()
+      .filter((admin) => admin)
+
+    res.status(200).json({'Admins': orgAdminsFiltered})
+  } catch (err) {
+    next(err)
+  }
+})
+
 app.post('/signUserOut', async (req, res, next) => {
   /**
    * To prevent rogue actions of users with escalated privilege signing

--- a/cdk/backend/function/AdminQueries/cognitoActions.js
+++ b/cdk/backend/function/AdminQueries/cognitoActions.js
@@ -168,11 +168,11 @@ async function listUsers(Limit, PaginationToken) {
   }
 }
 
-async function listGroups(Limit, PaginationToken) {
+async function listGroups(Limit, NextToken) {
   const params = {
     UserPoolId: userPoolId,
     ...(Limit && { Limit }),
-    ...(PaginationToken && { PaginationToken }),
+    ...(NextToken && { NextToken }),
   }
 
   console.log('Attempting to list groups')
@@ -181,10 +181,6 @@ async function listGroups(Limit, PaginationToken) {
     const result = await cognitoIdentityServiceProvider
       .listGroups(params)
       .promise()
-
-    // Rename to NextToken for consistency with other Cognito APIs
-    result.NextToken = result.PaginationToken
-    delete result.PaginationToken
 
     return result
   } catch (err) {

--- a/frontend/src/components/AdminPanel/AddUserToGroupDialog.tsx
+++ b/frontend/src/components/AdminPanel/AddUserToGroupDialog.tsx
@@ -30,6 +30,7 @@ const AddUserToGroupDialog = ({
   searchFieldPlaceholder,
   title,
   confirmButtonText,
+  showOrgId,
 }: any) => {
   const { t } = useTranslation()
   const style = dialogStyles()
@@ -107,6 +108,7 @@ const AddUserToGroupDialog = ({
             users={usersInList}
             selectedUser={selectedUser}
             setSelectedUser={onSelect}
+            showOrgId={showOrgId}
           />
         )}
       </DialogContent>

--- a/frontend/src/components/AdminPanel/DeleteUserFromGroupDialog.tsx
+++ b/frontend/src/components/AdminPanel/DeleteUserFromGroupDialog.tsx
@@ -11,6 +11,7 @@ import ErrorIcon from '@mui/icons-material/Error'
 import { dialogStyles } from '../../styles'
 import { getAttribute } from './helpers'
 import { useTranslation } from 'react-i18next'
+import { ORGANIZATION_ID_ATTRIBUTE } from '../../constants'
 
 const DeleteUserFromGroupDialog = ({
   onCancel,
@@ -21,6 +22,7 @@ const DeleteUserFromGroupDialog = ({
   roleName,
   disableRoleSuffix,
   children,
+  showOrgId,
 }: any) => {
   const { t } = useTranslation()
   const style = dialogStyles()
@@ -48,10 +50,19 @@ const DeleteUserFromGroupDialog = ({
       </DialogTitle>
       <DialogContent>
         <DialogContentText>
-          {t('admin.areYouSureYouWantToRemoveNameFromRole', {
-            name: name,
-            role: role,
-          }) + ' '}
+          {showOrgId === true
+            ? t(
+                'superAdmin.areYouSureYouWantToRemoveNameFromRoleAtOrganization',
+                {
+                  name: name,
+                  role: role,
+                  organization: getAttribute(user, ORGANIZATION_ID_ATTRIBUTE),
+                }
+              ) + ' '
+            : t('admin.areYouSureYouWantToRemoveNameFromRole', {
+                name: name,
+                role: role,
+              }) + ' '}
           {children}
         </DialogContentText>
       </DialogContent>

--- a/frontend/src/components/AdminPanel/UsersTable.tsx
+++ b/frontend/src/components/AdminPanel/UsersTable.tsx
@@ -12,11 +12,13 @@ import Table from '../mui/Table'
 import TableRow from '../mui/TableRow'
 import PictureAndNameCell from './PictureAndNameCell'
 import { useTranslation } from 'react-i18next'
+import { ORGANIZATION_ID_ATTRIBUTE } from '../../constants'
 
-const User = ({ user, selected, setSelectedUser }: any) => {
+const User = ({ user, selected, setSelectedUser, showOrgId }: any) => {
   const name = getAttribute(user, 'name')
   const email = getAttribute(user, 'email')
   const picture = getAttribute(user, 'picture')
+  const orgId = getAttribute(user, ORGANIZATION_ID_ATTRIBUTE)
 
   return (
     <>
@@ -25,12 +27,18 @@ const User = ({ user, selected, setSelectedUser }: any) => {
           <PictureAndNameCell name={name} picture={picture} />
         </TableCell>
         <TableCell>{email}</TableCell>
+        {showOrgId && <TableCell>{orgId}</TableCell>}
       </TableRow>
     </>
   )
 }
 
-const UsersTable = ({ users, selectedUser, setSelectedUser }: any) => {
+const UsersTable = ({
+  users,
+  selectedUser,
+  setSelectedUser,
+  showOrgId,
+}: any) => {
   const { t } = useTranslation()
   const isSelected = (user: any) =>
     selectedUser && user.Username === selectedUser.Username
@@ -45,6 +53,7 @@ const UsersTable = ({ users, selectedUser, setSelectedUser }: any) => {
           <TableRow>
             <TableCell>{t('employee')}</TableCell>
             <TableCell>{t('email')}</TableCell>
+            {showOrgId && <TableCell>{t('organizationID')}</TableCell>}
           </TableRow>
         </TableHead>
         <TableBody>
@@ -54,6 +63,7 @@ const UsersTable = ({ users, selectedUser, setSelectedUser }: any) => {
               user={u}
               selected={isSelected(u)}
               setSelectedUser={setSelectedUser}
+              showOrgId={showOrgId}
             />
           ))}
         </TableBody>

--- a/frontend/src/components/AdminPanel/adminApi.tsx
+++ b/frontend/src/components/AdminPanel/adminApi.tsx
@@ -180,6 +180,30 @@ const listAllUsers = async (limit = 60): Promise<ApiResponse<any[]>> => {
   return { result: allUsers }
 }
 
+const listAllOrganizationAdministrators = async (): Promise<
+  ApiResponse<any[]>
+> => {
+  const apiName = 'AdminQueries'
+  const path = '/listAllOrganizationAdministrators'
+  const myInit = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `${(await Auth.currentSession())
+        .getAccessToken()
+        .getJwtToken()}`,
+    },
+  }
+
+  try {
+    const res = await API.get(apiName, path, myInit)
+    return { result: res.Admins }
+  } catch (e) {
+    return {
+      error: i18n.t('adminApi.error.couldNotGetAListOfAllAdministrators'),
+    }
+  }
+}
+
 export {
   listAllUsers,
   listAllUsersInOrganization,
@@ -187,4 +211,5 @@ export {
   listGroupLeadersInOrganization,
   listSuperAdmins,
   listAdminsInOrganization,
+  listAllOrganizationAdministrators,
 }

--- a/frontend/src/components/AdminPanel/helpers.tsx
+++ b/frontend/src/components/AdminPanel/helpers.tsx
@@ -1,5 +1,13 @@
+import {
+  ADMIN_COGNITOGROUP_SUFFIX,
+  ORGANIZATION_ID_ATTRIBUTE,
+} from '../../constants'
+
 const getAttribute = (user: any, attribute: string): string | undefined =>
   user?.Attributes?.find((attr: any) => attr.Name === attribute)?.Value
+
+const getOrganizationAdminGroupNameFromUser = (user: any): string =>
+  getAttribute(user, ORGANIZATION_ID_ATTRIBUTE) + ADMIN_COGNITOGROUP_SUFFIX
 
 const not = (a: any, b: any) =>
   a.filter((av: any) => !b.some((bv: any) => bv.Username === av.Username))
@@ -21,4 +29,11 @@ const compareByIndex = (a: any, b: any) => {
 const compareByCreatedAt = (a: any, b: any) =>
   Date.parse(a.createdAt) > Date.parse(b.createdAt) ? -1 : 1
 
-export { getAttribute, not, compareByName, compareByIndex, compareByCreatedAt }
+export {
+  getAttribute,
+  not,
+  compareByName,
+  compareByIndex,
+  compareByCreatedAt,
+  getOrganizationAdminGroupNameFromUser,
+}

--- a/frontend/src/components/SuperAdminPanel/EditOrganizationAdmins.tsx
+++ b/frontend/src/components/SuperAdminPanel/EditOrganizationAdmins.tsx
@@ -7,7 +7,6 @@ import Container from '@mui/material/Container'
 import Typography from '@mui/material/Typography'
 import PersonAddIcon from '@mui/icons-material/PersonAdd'
 
-import { getOrganizationAdminGroupNameFromUser } from '../../redux/User'
 import { useTranslation } from 'react-i18next'
 import AddUserToGroupDialog from '../AdminPanel/AddUserToGroupDialog'
 import {
@@ -21,6 +20,7 @@ import DeleteUserFromGroupDialog from '../AdminPanel/DeleteUserFromGroupDialog'
 import useApiGet from '../AdminPanel/useApiGet'
 import Button from '../mui/Button'
 import AdminTable from '../AdminPanel/AdminTable'
+import { getOrganizationAdminGroupNameFromUser } from '../AdminPanel/helpers'
 
 const EditOrganizationAdmins = () => {
   const { t } = useTranslation()
@@ -94,6 +94,7 @@ const EditOrganizationAdmins = () => {
         onConfirm={deleteAdminConfirm}
         user={adminToDelete}
         roleName={t('administrator').toLowerCase()}
+        showOrgId
       />
       {showAddAdmin && (
         <AddUserToGroupDialog
@@ -104,6 +105,7 @@ const EditOrganizationAdmins = () => {
           onConfirm={addAdminConfirm}
           roleName={t('administrator').toLowerCase()}
           searchFieldPlaceholder={t('searchForEmployeeAcrossOrganizations')}
+          showOrgId
         />
       )}
     </Container>

--- a/frontend/src/components/SuperAdminPanel/EditSuperAdmins.tsx
+++ b/frontend/src/components/SuperAdminPanel/EditSuperAdmins.tsx
@@ -94,6 +94,7 @@ const EditSuperAdmins = () => {
         roleName={t(
           'superAdmin.editSuperAdministrators.superAdministrator'
         ).toLowerCase()}
+        showOrgId
       />
       {showAddAdmin && (
         <AddUserToGroupDialog

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -264,7 +264,7 @@ export const English: LanguageSchema = {
         addSuperAdministrator: 'Add super-administrator',
       },
       editOrganizationAdministrators: {
-        description: 'On this page you can add and remove administrators for specific organizations.',
+        description: 'On this page you can add and remove users to and from the administrator role for their organization.',
         couldNotGetAListOfAllAdministrators: 'Could not get a list of all administrators.',
       }
     },

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -264,6 +264,7 @@ export const English: LanguageSchema = {
       },
       editOrganizationAdministrators: {
         description: 'On this page you can add and remove administrators for specific organizations.',
+        couldNotGetAListOfAllAdministrators: 'Could not get a list of all administrators.',
       }
     },
     adminApi: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -245,6 +245,7 @@ export const English: LanguageSchema = {
     },
     superAdmin: {
       identifierAttribute: 'Identifier Attribute',
+      areYouSureYouWantToRemoveNameFromRoleAtOrganization: 'Are you sure you want to remove {{name}} from the {{role}} at {{organization}}?',
       editOrganizations: {
         description: 'On this page you can add, remove and update organizations.',
         id: 'ID',

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -264,6 +264,7 @@ export const Norwegian: LanguageSchema = {
       },
       editOrganizationAdministrators: {
         description: 'På denne siden kan du legge til og fjerne administratorer for spesifikke organisasjoner.',
+        couldNotGetAListOfAllAdministrators: 'Kunne ikke hente liste over alle administratorer.',
       }
     },
     adminApi: {

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -264,7 +264,7 @@ export const Norwegian: LanguageSchema = {
         addSuperAdministrator: 'Legg til super-administrator',
       },
       editOrganizationAdministrators: {
-        description: 'På denne siden kan du legge til og fjerne administratorer for spesifikke organisasjoner.',
+        description: 'På denne siden kan brukere legges til, og fjernes fra, administrator-rollen for organisasjonen de er en del av.',
         couldNotGetAListOfAllAdministrators: 'Kunne ikke hente liste over alle administratorer.',
       }
     },

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -245,6 +245,7 @@ export const Norwegian: LanguageSchema = {
     },
     superAdmin: {
       identifierAttribute: 'Identifier Attribute',
+      areYouSureYouWantToRemoveNameFromRoleAtOrganization: 'Er du sikker på at du har lyst til å fjerne {{name}} fra {{role}} i {{organization}}?',
       editOrganizations: {
         description: 'På denne siden kan du legge til, fjerne og oppdatere organisasjoner.',
         id: 'ID',

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -244,7 +244,7 @@ export const Norwegian: LanguageSchema = {
       }
     },
     superAdmin: {
-      identifierAttribute: 'Identifier Attribute',
+      identifierAttribute: 'Identifikatorattributt',
       areYouSureYouWantToRemoveNameFromRoleAtOrganization: 'Er du sikker på at du har lyst til å fjerne {{name}} fra {{role}} i {{organization}}?',
       editOrganizations: {
         description: 'På denne siden kan du legge til, fjerne og oppdatere organisasjoner.',

--- a/frontend/src/i18n/schema.ts
+++ b/frontend/src/i18n/schema.ts
@@ -243,6 +243,7 @@ export type LanguageSchema = {
     }
     superAdmin: {
       identifierAttribute: string
+      areYouSureYouWantToRemoveNameFromRoleAtOrganization: string
       editOrganizations: {
         description: string
         id: string

--- a/frontend/src/i18n/schema.ts
+++ b/frontend/src/i18n/schema.ts
@@ -262,6 +262,7 @@ export type LanguageSchema = {
       }
       editOrganizationAdministrators: {
         description: string
+        couldNotGetAListOfAllAdministrators: string
       }
     }
     adminApi: {

--- a/frontend/src/redux/User.ts
+++ b/frontend/src/redux/User.ts
@@ -2,7 +2,6 @@ import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import {
   ADMIN_COGNITOGROUP_SUFFIX,
   GROUPLEADER_COGNITOGROUP_SUFFIX,
-  ORGANIZATION_ID_ATTRIBUTE,
   SUPER_ADMIN_COGNITO_GROUP,
 } from '../constants'
 import { getOrganizationNameByID } from '../helperFunctions'
@@ -10,7 +9,6 @@ import { RootState } from './store'
 
 import { UserRole } from '../types'
 import i18n from '../i18n/i18n'
-import { getAttribute } from '../components/AdminPanel/helpers'
 
 const initialState = {
   userState: {
@@ -148,6 +146,3 @@ export const selectAdminCognitoGroupName = (state: RootState) => {
 export const selectGroupLeaderCognitoGroupName = (state: RootState) => {
   return state.user.userState.organizationID + GROUPLEADER_COGNITOGROUP_SUFFIX
 }
-
-export const getOrganizationAdminGroupNameFromUser = (user: any): string =>
-  getAttribute(user, ORGANIZATION_ID_ATTRIBUTE) + ADMIN_COGNITOGROUP_SUFFIX

--- a/frontend/src/redux/User.ts
+++ b/frontend/src/redux/User.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit'
 import {
   ADMIN_COGNITOGROUP_SUFFIX,
   GROUPLEADER_COGNITOGROUP_SUFFIX,
+  ORGANIZATION_ID_ATTRIBUTE,
   SUPER_ADMIN_COGNITO_GROUP,
 } from '../constants'
 import { getOrganizationNameByID } from '../helperFunctions'
@@ -9,6 +10,7 @@ import { RootState } from './store'
 
 import { UserRole } from '../types'
 import i18n from '../i18n/i18n'
+import { getAttribute } from '../components/AdminPanel/helpers'
 
 const initialState = {
   userState: {
@@ -146,3 +148,6 @@ export const selectAdminCognitoGroupName = (state: RootState) => {
 export const selectGroupLeaderCognitoGroupName = (state: RootState) => {
   return state.user.userState.organizationID + GROUPLEADER_COGNITOGROUP_SUFFIX
 }
+
+export const getOrganizationAdminGroupNameFromUser = (user: any): string =>
+  getAttribute(user, ORGANIZATION_ID_ATTRIBUTE) + ADMIN_COGNITOGROUP_SUFFIX


### PR DESCRIPTION
* Viser nå alle (org)admins på tvers av organisasjoner
* Viser nå hvilken organisasjon hver administrator tilhører
* Legg til-dialogen viser nå alle brukere på tvers av organisasjoner, samt hvilken org de tilhører
* Fjern-dialogen viser nå hvilken organisasjon man er i ferd med å fjerne administrator for:<img width="417" alt="Screenshot 2023-04-17 at 15 58 26" src="https://user-images.githubusercontent.com/72893130/232506386-b3c50b09-29b1-46ba-989f-85657d693978.png">

Som superadmin kan man ikke velge hvilken org man legger til administrator for. Brukeren man velger blir admin for organisasjonen de allerede er i. Dette er kanskje ikke selvforklarende i GUI-et, bør vi gjøre noe med det? Evt. forslag til hvordan?

For å unngå mange nettverkskall og begrense prosessering i frontend-en, tar endepunktet `/listAllOrganizationAdministrators` av seg alt (hente alle grupper, filtrere grupper og hente brukere fra hver gruppe). Dette medfører at endepunktet ikke bruker `limit`, fordi det vil være komplisert å overholde.

closes #154 