### PR TITLE
Remove import React from 'react'

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,10 +58,6 @@
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off"
     },
-    "globals": {
-      "React": "readonly",
-      "JSX": "readonly"
-    },
     "ignorePatterns": [
       "API.ts",
       "exports.js",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import './App.css'
 import { API, Auth, Hub } from 'aws-amplify'
 // import awsconfig from "./aws-exports";

--- a/frontend/src/components/AdminPanel/AdminMenu.tsx
+++ b/frontend/src/components/AdminPanel/AdminMenu.tsx
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction } from 'react'
 import { Button } from '@mui/material'
 import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
@@ -7,7 +8,7 @@ import { Panel } from '../../types'
 type AdminMenuProps = {
   show: boolean
   selected: boolean
-  setShowFab: React.Dispatch<React.SetStateAction<boolean>>
+  setShowFab: Dispatch<SetStateAction<boolean>>
   style: any
   activeSubmenuItem: any
   setActiveSubmenuItem: any

--- a/frontend/src/components/AdminPanel/AdminMenu.tsx
+++ b/frontend/src/components/AdminPanel/AdminMenu.tsx
@@ -2,7 +2,6 @@ import { Button } from '@mui/material'
 import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
 import { SubmenuCategory } from './AdminPanel'
-import React from 'react'
 import { Panel } from '../../types'
 
 type AdminMenuProps = {

--- a/frontend/src/components/AdminPanel/DeleteGroupDialog.tsx
+++ b/frontend/src/components/AdminPanel/DeleteGroupDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'

--- a/frontend/src/components/AdminPanel/DeleteUserFromGroupDialog.tsx
+++ b/frontend/src/components/AdminPanel/DeleteUserFromGroupDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'

--- a/frontend/src/components/AdminPanel/DownloadExcel.tsx
+++ b/frontend/src/components/AdminPanel/DownloadExcel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import { CardContent, Typography } from '@mui/material'
 import { listAllFormDefinitionsForLoggedInUser } from './catalogApi'

--- a/frontend/src/components/AdminPanel/EditCatalogs/ActivateCatalogDialog.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/ActivateCatalogDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'

--- a/frontend/src/components/AdminPanel/EditCatalogs/Breadcrumbs.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/Breadcrumbs.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { makeStyles, createStyles } from '@mui/styles'
 import { Theme } from '@mui/material/styles'
 import Link, { LinkProps } from '@mui/material/Link'

--- a/frontend/src/components/AdminPanel/EditCatalogs/CategoriesSelect.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/CategoriesSelect.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createStyles, withStyles, makeStyles } from '@mui/styles'
 import { Theme } from '@mui/material/styles'
 import InputLabel from '@mui/material/InputLabel'

--- a/frontend/src/components/AdminPanel/EditCatalogs/CopyCatalogDialog.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/CopyCatalogDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'

--- a/frontend/src/components/AdminPanel/EditCatalogs/DeleteCatalogDialog.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/DeleteCatalogDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'

--- a/frontend/src/components/AdminPanel/EditCatalogs/DeleteQuestionDialog.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/DeleteQuestionDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'

--- a/frontend/src/components/AdminPanel/EditCatalogs/EditActionButtons.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/EditActionButtons.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { makeStyles, createStyles } from '@mui/styles'
 import Button from '@mui/material/Button'
 import { KnowitColors } from '../../../styles'

--- a/frontend/src/components/AdminPanel/EditCatalogs/EditCatalog.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/EditCatalog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { makeStyles, createStyles } from '@mui/styles'

--- a/frontend/src/components/AdminPanel/EditCatalogs/Root.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogs/Root.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 
 import Container from '@mui/material/Container'

--- a/frontend/src/components/AdminPanel/EditCatalogsRouter.tsx
+++ b/frontend/src/components/AdminPanel/EditCatalogsRouter.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { Route, Switch } from 'react-router'
 

--- a/frontend/src/components/AdminPanel/PictureAndNameCell.tsx
+++ b/frontend/src/components/AdminPanel/PictureAndNameCell.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Avatar from '@mui/material/Avatar'
 import { makeStyles } from '@mui/styles'
 

--- a/frontend/src/components/AdminPanel/UsersTable.tsx
+++ b/frontend/src/components/AdminPanel/UsersTable.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import commonStyles from './common.module.css'
 import TableBody from '@mui/material/TableBody'
 import TableCell from '@mui/material/TableCell'

--- a/frontend/src/components/AlertDialog.tsx
+++ b/frontend/src/components/AlertDialog.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Dialog,
   Button,

--- a/frontend/src/components/AnswerDiagram.tsx
+++ b/frontend/src/components/AnswerDiagram.tsx
@@ -1,5 +1,4 @@
 import { makeStyles } from '@mui/styles'
-import React from 'react'
 import { QuestionType } from '../API'
 import {
   AnswerDiagramProps,

--- a/frontend/src/components/AnswerHistory.tsx
+++ b/frontend/src/components/AnswerHistory.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'

--- a/frontend/src/components/BlockInfo.tsx
+++ b/frontend/src/components/BlockInfo.tsx
@@ -1,7 +1,6 @@
 import { makeStyles } from '@mui/styles'
 import { KnowitColors } from '../styles'
 import { QuestionAnswer } from '../types'
-import React from 'react'
 import CheckCircleOutlineRoundedIcon from '@mui/icons-material/CheckCircleOutlineRounded'
 import ErrorOutlineRoundedIcon from '@mui/icons-material/ErrorOutlineRounded'
 import UpdateIcon from '@mui/icons-material/Update'

--- a/frontend/src/components/CombinedChart.tsx
+++ b/frontend/src/components/CombinedChart.tsx
@@ -1,5 +1,4 @@
 import makeStyles from '@mui/styles/makeStyles'
-import React from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   BarChart,

--- a/frontend/src/components/Content.tsx
+++ b/frontend/src/components/Content.tsx
@@ -1,7 +1,7 @@
 import { Button, ListItem } from '@mui/material'
 import { makeStyles } from '@mui/styles'
 import clsx from 'clsx'
-import React, { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import { CreateQuestionAnswerInput, QuestionType } from '../API'
 import * as customQueries from '../graphql/custom-queries'
 import * as helper from '../helperFunctions'

--- a/frontend/src/components/Content.tsx
+++ b/frontend/src/components/Content.tsx
@@ -1,7 +1,7 @@
 import { Button, ListItem } from '@mui/material'
 import { makeStyles } from '@mui/styles'
 import clsx from 'clsx'
-import { Fragment, useEffect, useState } from 'react'
+import { Dispatch, Fragment, SetStateAction, useEffect, useState } from 'react'
 import { CreateQuestionAnswerInput, QuestionType } from '../API'
 import * as customQueries from '../graphql/custom-queries'
 import * as helper from '../helperFunctions'
@@ -144,7 +144,7 @@ const contentStyle = makeStyles({
 
 const updateCategoryAlerts = (
   questionAnswers: Map<string, QuestionAnswer[]>,
-  setAlerts: React.Dispatch<React.SetStateAction<AlertState | undefined>>,
+  setAlerts: Dispatch<SetStateAction<AlertState | undefined>>,
   t: TFunction<'translation', undefined, 'translation'>
 ) => {
   const msNow = Date.now()

--- a/frontend/src/components/DescriptionTable.tsx
+++ b/frontend/src/components/DescriptionTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as Icon from '../icons/iconController'
 import { makeStyles } from '@mui/styles'
 import clsx from 'clsx'

--- a/frontend/src/components/DescriptionTable.tsx
+++ b/frontend/src/components/DescriptionTable.tsx
@@ -1,3 +1,4 @@
+import { FunctionComponent, MouseEventHandler, SVGProps } from 'react'
 import * as Icon from '../icons/iconController'
 import { makeStyles } from '@mui/styles'
 import clsx from 'clsx'
@@ -93,7 +94,7 @@ type ScaleContainerProps = {
 }
 
 type ScaleContainerObject = {
-  icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>
+  icon: FunctionComponent<SVGProps<SVGSVGElement>>
   heading: string
   text: string
 }
@@ -168,7 +169,7 @@ const getMotivation = (): ScaleContainerObject[] => [
 ]
 
 type DescriptionTableProps = {
-  onClose: React.MouseEventHandler<HTMLButtonElement>
+  onClose: MouseEventHandler<HTMLButtonElement>
   isMobile: boolean
 }
 

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,5 +1,3 @@
-// import React from 'react'
-
 export const Footer = () => {
   return (
     <div>

--- a/frontend/src/components/GroupLeaderPanel/GroupLeaderMenu.tsx
+++ b/frontend/src/components/GroupLeaderPanel/GroupLeaderMenu.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import clsx from 'clsx'
 
 import { Button } from '@mui/material'

--- a/frontend/src/components/GroupLeaderPanel/GroupMember.tsx
+++ b/frontend/src/components/GroupLeaderPanel/GroupMember.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 
 import CircularProgress from '@mui/material/CircularProgress'
 

--- a/frontend/src/components/GroupLeaderPanel/Nav.tsx
+++ b/frontend/src/components/GroupLeaderPanel/Nav.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { createStyles, makeStyles, withStyles } from '@mui/styles'
 import { Theme } from '@mui/material/styles'
 import InputBase from '@mui/material/InputBase'

--- a/frontend/src/components/NavBarDesktop.tsx
+++ b/frontend/src/components/NavBarDesktop.tsx
@@ -19,7 +19,14 @@ import {
 } from '@mui/material'
 import { makeStyles } from '@mui/styles'
 import HelpIcon from '@mui/icons-material/Help'
-import { useEffect, useRef, useState } from 'react'
+import {
+  KeyboardEvent,
+  MouseEvent,
+  TouchEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import ReactMarkdown from 'react-markdown'
 import { ReactComponent as KnowitLogo } from '../Logotype-Knowit-Digital-white 1.svg'
 import { useAppSelector } from '../redux/hooks'
@@ -105,14 +112,14 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
     setAvatarMenuOpen(false)
   }
 
-  function handleListKeyDown(event: React.KeyboardEvent) {
+  function handleListKeyDown(event: KeyboardEvent) {
     if (event.key === 'Tab') {
       event.preventDefault()
       setAvatarMenuOpen(false)
     }
   }
 
-  const handleCloseSignout = (event: React.MouseEvent<EventTarget>) => {
+  const handleCloseSignout = (event: MouseEvent<EventTarget>) => {
     if (
       anchorRef.current &&
       anchorRef.current.contains(event.target as HTMLElement)
@@ -123,7 +130,7 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
     props.signout()
   }
 
-  // const handleDeleteAnswers = (event: React.MouseEvent<EventTarget>) => {
+  // const handleDeleteAnswers = (event: MouseEvent<EventTarget>) => {
   //     if (
   //         anchorRef.current &&
   //         anchorRef.current.contains(event.target as HTMLElement)
@@ -137,7 +144,7 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
     setDeleteAlertOpen(false)
   }
 
-  // const handleDisplayAnswers = (event: React.MouseEvent<EventTarget>) => {
+  // const handleDisplayAnswers = (event: MouseEvent<EventTarget>) => {
   //     if (
   //         anchorRef.current &&
   //         anchorRef.current.contains(event.target as HTMLElement)

--- a/frontend/src/components/NavBarDesktop.tsx
+++ b/frontend/src/components/NavBarDesktop.tsx
@@ -19,14 +19,7 @@ import {
 } from '@mui/material'
 import { makeStyles } from '@mui/styles'
 import HelpIcon from '@mui/icons-material/Help'
-import {
-  KeyboardEvent,
-  MouseEvent,
-  TouchEvent,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import { KeyboardEvent, useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { ReactComponent as KnowitLogo } from '../Logotype-Knowit-Digital-white 1.svg'
 import { useAppSelector } from '../redux/hooks'
@@ -119,7 +112,7 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
     }
   }
 
-  const handleCloseSignout = (event: MouseEvent<EventTarget>) => {
+  const handleCloseSignout = (event: React.MouseEvent<EventTarget>) => {
     if (
       anchorRef.current &&
       anchorRef.current.contains(event.target as HTMLElement)
@@ -130,7 +123,7 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
     props.signout()
   }
 
-  // const handleDeleteAnswers = (event: MouseEvent<EventTarget>) => {
+  // const handleDeleteAnswers = (event: React.MouseEvent<EventTarget>) => {
   //     if (
   //         anchorRef.current &&
   //         anchorRef.current.contains(event.target as HTMLElement)
@@ -144,7 +137,7 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
     setDeleteAlertOpen(false)
   }
 
-  // const handleDisplayAnswers = (event: MouseEvent<EventTarget>) => {
+  // const handleDisplayAnswers = (event: React.MouseEvent<EventTarget>) => {
   //     if (
   //         anchorRef.current &&
   //         anchorRef.current.contains(event.target as HTMLElement)

--- a/frontend/src/components/NavBarDesktop.tsx
+++ b/frontend/src/components/NavBarDesktop.tsx
@@ -19,7 +19,7 @@ import {
 } from '@mui/material'
 import { makeStyles } from '@mui/styles'
 import HelpIcon from '@mui/icons-material/Help'
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { ReactComponent as KnowitLogo } from '../Logotype-Knowit-Digital-white 1.svg'
 import { useAppSelector } from '../redux/hooks'
@@ -84,7 +84,7 @@ const NavBarDesktop = ({ ...props }: NavBarPropsDesktop) => {
 
   const [avatarMenuOpen, setAvatarMenuOpen] = useState<boolean>(false)
   // return focus to the button when we transitioned from !avatarMenuOpen -> avatarMenuOpen
-  const avatarMenuPrevOpen = React.useRef(avatarMenuOpen)
+  const avatarMenuPrevOpen = useRef(avatarMenuOpen)
   const style = navbarStyles()
 
   const [deleteAlertOpen, setDeleteAlertOpen] = useState<boolean>(false)

--- a/frontend/src/components/NavBarMobile.tsx
+++ b/frontend/src/components/NavBarMobile.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import {
   AppBar,
   Toolbar,
@@ -7,7 +8,6 @@ import {
   ListItem,
 } from '@mui/material'
 import { makeStyles } from '@mui/styles'
-import React from 'react'
 import { KnowitColors } from '../styles'
 import { NavBarPropsMobile } from '../types'
 import MenuIcon from '@mui/icons-material/Menu'
@@ -94,7 +94,7 @@ const NavBarMobile = ({ ...props }: NavBarPropsMobile) => {
   const { t } = useTranslation()
   const style = navbarStyles()
   // const [mobileOpen, setMobileOpen] = React.useState(false);
-  const [drawerOpen, setDrawerOpen] = React.useState(false)
+  const [drawerOpen, setDrawerOpen] = useState(false)
 
   // const handleDrawerToggle = () => {
   //   setMobileOpen(!mobileOpen);

--- a/frontend/src/components/NavBarMobile.tsx
+++ b/frontend/src/components/NavBarMobile.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { KeyboardEvent, MouseEvent, useState } from 'react'
 import {
   AppBar,
   Toolbar,
@@ -93,7 +93,7 @@ const navbarStyles = makeStyles((theme) => ({
 const NavBarMobile = ({ ...props }: NavBarPropsMobile) => {
   const { t } = useTranslation()
   const style = navbarStyles()
-  // const [mobileOpen, setMobileOpen] = React.useState(false);
+  // const [mobileOpen, setMobileOpen] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false)
 
   // const handleDrawerToggle = () => {
@@ -111,12 +111,12 @@ const NavBarMobile = ({ ...props }: NavBarPropsMobile) => {
   }
 
   const toggleDrawer =
-    (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
+    (open: boolean) => (event: KeyboardEvent | MouseEvent) => {
       if (
         event &&
         event.type === 'keydown' &&
-        ((event as React.KeyboardEvent).key === 'Tab' ||
-          (event as React.KeyboardEvent).key === 'Shift')
+        ((event as KeyboardEvent).key === 'Tab' ||
+          (event as KeyboardEvent).key === 'Shift')
       ) {
         return
       }

--- a/frontend/src/components/Question.tsx
+++ b/frontend/src/components/Question.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import clsx from 'clsx'
 import { QuestionType } from '../API'
 import { QuestionProps, SliderKnowledgeMotivationValues } from '../types'

--- a/frontend/src/components/Selector.tsx
+++ b/frontend/src/components/Selector.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 type Props = {
   radiobuttonChanged: (value: number, motivation: boolean) => void
   questionId: string

--- a/frontend/src/components/Selector.tsx
+++ b/frontend/src/components/Selector.tsx
@@ -1,3 +1,5 @@
+import { ChangeEvent } from 'react'
+
 type Props = {
   radiobuttonChanged: (value: number, motivation: boolean) => void
   questionId: string
@@ -6,7 +8,7 @@ type Props = {
 }
 
 const Selector = ({ ...props }: Props) => {
-  const radiobuttonChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const radiobuttonChanged = (event: ChangeEvent<HTMLInputElement>) => {
     props.radiobuttonChanged(parseInt(event.target.value), props.motivation)
   }
 

--- a/frontend/src/components/Slider.tsx
+++ b/frontend/src/components/Slider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { SliderProps } from '../types'
 import * as helper from '../helperFunctions'
 import { KnowitColors } from '../styles'

--- a/frontend/src/components/SuperAdminPanel/AddOrganizationDialog.tsx
+++ b/frontend/src/components/SuperAdminPanel/AddOrganizationDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { FC, useState } from 'react'
 
 import Button from '@mui/material/Button'
 
@@ -21,7 +21,7 @@ interface AddOrganizationDialogProps {
   open: boolean
 }
 
-const AddOrganizationDialog: React.FC<AddOrganizationDialogProps> = ({
+const AddOrganizationDialog: FC<AddOrganizationDialogProps> = ({
   onCancel,
   onConfirm,
   open,

--- a/frontend/src/components/SuperAdminPanel/AddOrganizationDialog.tsx
+++ b/frontend/src/components/SuperAdminPanel/AddOrganizationDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import Button from '@mui/material/Button'
 

--- a/frontend/src/components/SuperAdminPanel/DeleteOrganizationDialog.tsx
+++ b/frontend/src/components/SuperAdminPanel/DeleteOrganizationDialog.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'

--- a/frontend/src/components/SuperAdminPanel/DeleteOrganizationDialog.tsx
+++ b/frontend/src/components/SuperAdminPanel/DeleteOrganizationDialog.tsx
@@ -1,3 +1,4 @@
+import { FC } from 'react'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -17,7 +18,7 @@ interface DeleteOrganiationDialogProps {
   organization: OrganizationInfo
 }
 
-const DeleteOrganizationDialog: React.FC<DeleteOrganiationDialogProps> = ({
+const DeleteOrganizationDialog: FC<DeleteOrganiationDialogProps> = ({
   open,
   onConfirm,
   onCancel,

--- a/frontend/src/components/SuperAdminPanel/EditOrganizations.tsx
+++ b/frontend/src/components/SuperAdminPanel/EditOrganizations.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { FC, useState } from 'react'
 
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
@@ -34,7 +34,7 @@ interface OrganizationProps {
   deleteOrganization: (id: OrganizationInfo) => void
 }
 
-const Organization: React.FC<OrganizationProps> = ({
+const Organization: FC<OrganizationProps> = ({
   organization,
   deleteOrganization,
 }) => {
@@ -63,7 +63,7 @@ interface OrganizationTableProps {
   deleteOrganization: (id: OrganizationInfo) => void
 }
 
-const OrganizationTable: React.FC<OrganizationTableProps> = ({
+const OrganizationTable: FC<OrganizationTableProps> = ({
   organizations,
   deleteOrganization,
 }) => {

--- a/frontend/src/components/SuperAdminPanel/EditOrganizations.tsx
+++ b/frontend/src/components/SuperAdminPanel/EditOrganizations.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 
 import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'

--- a/frontend/src/components/SuperAdminPanel/SuperAdminMenu.tsx
+++ b/frontend/src/components/SuperAdminPanel/SuperAdminMenu.tsx
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction } from 'react'
 import { Button } from '@mui/material'
 import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
@@ -7,7 +8,7 @@ import { Panel } from '../../types'
 type SuperAdminMenuProps = {
   show: boolean
   selected: boolean
-  setShowFab: React.Dispatch<React.SetStateAction<boolean>>
+  setShowFab: Dispatch<SetStateAction<boolean>>
   style: any
   activeSubmenuItem: any
   setActiveSubmenuItem: any

--- a/frontend/src/components/SuperAdminPanel/SuperAdminMenu.tsx
+++ b/frontend/src/components/SuperAdminPanel/SuperAdminMenu.tsx
@@ -2,7 +2,6 @@ import { Button } from '@mui/material'
 import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
 import { SubmenuCategory } from './SuperAdminPanel'
-import React from 'react'
 import { Panel } from '../../types'
 
 type SuperAdminMenuProps = {

--- a/frontend/src/components/TypedOverviewChart.tsx
+++ b/frontend/src/components/TypedOverviewChart.tsx
@@ -1,6 +1,6 @@
 import Button from '@mui/material/Button'
 import { makeStyles } from '@mui/styles'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { roundDecimals } from '../helperFunctions'
 import { KnowitColors } from '../styles'
 import { ChartData, ResultData, ResultDiagramProps } from '../types'

--- a/frontend/src/components/TypedOverviewChart.tsx
+++ b/frontend/src/components/TypedOverviewChart.tsx
@@ -1,6 +1,6 @@
 import Button from '@mui/material/Button'
 import { makeStyles } from '@mui/styles'
-import { useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { roundDecimals } from '../helperFunctions'
 import { KnowitColors } from '../styles'
 import { ChartData, ResultData, ResultDiagramProps } from '../types'
@@ -86,7 +86,7 @@ const recalculate = (
   createAverageData: () => ResultData[],
   createMedianData: () => ResultData[],
   createHighestData: () => ResultData[],
-  setChartData: React.Dispatch<React.SetStateAction<ChartData[]>>,
+  setChartData: Dispatch<SetStateAction<ChartData[]>>,
   isMobile: boolean
 ) => {
   let answerData: ResultData[] = []

--- a/frontend/src/components/YourAnswersDesktop.tsx
+++ b/frontend/src/components/YourAnswersDesktop.tsx
@@ -1,7 +1,7 @@
+import { useRef } from 'react'
 import { Button } from '@mui/material'
 import { makeStyles } from '@mui/styles'
 import clsx from 'clsx'
-import React from 'react'
 import { KnowitColors } from '../styles'
 import { Panel, YourAnswerProps } from '../types'
 import AnswerDiagram from './AnswerDiagram'
@@ -163,7 +163,7 @@ export const YourAnswersDesktop = ({ ...props }: YourAnswerProps) => {
   const { t } = useTranslation()
   const style = yourAnwersStyle()
 
-  const scrollRef = React.useRef<HTMLDivElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
 
   const scrollToTop = () => {
     scrollRef.current?.scroll(0, 0)

--- a/frontend/src/components/answersApi.ts
+++ b/frontend/src/components/answersApi.ts
@@ -11,10 +11,11 @@ import {
 } from '../types'
 import * as helper from '../helperFunctions'
 import * as customQueries from '../graphql/custom-queries'
+import { Dispatch, SetStateAction } from 'react'
 
 const createQuestionAnswers = (
   formDef: FormDefinition,
-  setCategories: React.Dispatch<React.SetStateAction<string[]>>
+  setCategories: Dispatch<SetStateAction<string[]>>
 ) => {
   // console.log("Creating questionAnswers with ", formDef);
   if (!formDef) return new Map()
@@ -61,9 +62,7 @@ const createQuestionAnswers = (
 }
 
 const fetchLastFormDefinition = async (
-  setFormDefinition: React.Dispatch<
-    React.SetStateAction<FormDefinition | null>
-  >,
+  setFormDefinition: Dispatch<SetStateAction<FormDefinition | null>>,
   createQuestionAnswers: (arg0: FormDefinition) => Map<any, any>,
   getUserAnswers: (arg0: FormDefinition) => Promise<void | UserAnswer[]>,
   setFirstAnswers: (arg0: any, arg1: any) => void
@@ -133,12 +132,12 @@ const fetchLastFormDefinition = async (
 const getUserAnswers = async (
   formDef: FormDefinition,
   userName: string,
-  setUserAnswers: React.Dispatch<React.SetStateAction<UserAnswer[]>>,
-  setActivePanel: React.Dispatch<React.SetStateAction<Panel>>,
-  setUserAnswersLoaded: React.Dispatch<React.SetStateAction<boolean>>,
-  setAnswerEditMode: React.Dispatch<React.SetStateAction<boolean>>,
-  setFirstTimeLogin: React.Dispatch<React.SetStateAction<boolean>>,
-  setScaleDescOpen: React.Dispatch<React.SetStateAction<boolean>>,
+  setUserAnswers: Dispatch<SetStateAction<UserAnswer[]>>,
+  setActivePanel: Dispatch<SetStateAction<Panel>>,
+  setUserAnswersLoaded: Dispatch<SetStateAction<boolean>>,
+  setAnswerEditMode: Dispatch<SetStateAction<boolean>>,
+  setFirstTimeLogin: Dispatch<SetStateAction<boolean>>,
+  setScaleDescOpen: Dispatch<SetStateAction<boolean>>,
   isMobile: boolean
 ) => {
   let nextToken: string | null = null
@@ -208,11 +207,9 @@ const getUserAnswers = async (
 const setFirstAnswers = (
   quAns: Map<string, QuestionAnswer[]>,
   newUserAnswers: UserAnswer[] | void,
-  setQuestionAnswers: React.Dispatch<
-    React.SetStateAction<Map<string, QuestionAnswer[]>>
-  >,
-  setAnswersBeforeSubmitted: React.Dispatch<
-    React.SetStateAction<Map<string, QuestionAnswer[]>>
+  setQuestionAnswers: Dispatch<SetStateAction<Map<string, QuestionAnswer[]>>>,
+  setAnswersBeforeSubmitted: Dispatch<
+    SetStateAction<Map<string, QuestionAnswer[]>>
   >
 ) => {
   // console.log(quAns, newUserAnswers);

--- a/frontend/src/components/cards/YourAnswers.tsx
+++ b/frontend/src/components/cards/YourAnswers.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { YourAnswerProps } from '../../types'
 import { YourAnswersMobile } from '../YourAnswersMobile'
 import { YourAnswersDesktop } from '../YourAnswersDesktop'

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { StrictMode } from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
 import App from './App'
@@ -7,10 +7,10 @@ import { store } from './redux/store'
 import './i18n/i18n'
 
 ReactDOM.render(
-  <React.StrictMode>
+  <StrictMode>
     <Provider store={store}>
       <App />
     </Provider>
-  </React.StrictMode>,
+  </StrictMode>,
   document.getElementById('root')
 )

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -1,7 +1,7 @@
 import { QuestionType } from './API'
 import { MenuButton } from './components/Content'
 import { AlertType } from './components/AlertNotification'
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, MutableRefObject, SetStateAction } from 'react'
 import { OverviewType } from './components/TypedOverviewChart'
 
 export interface UserState {
@@ -361,7 +361,7 @@ export type YourAnswerProps = {
     category?: string | undefined
   ) => void
   collapseMobileCategories: boolean
-  categoryNavRef: React.MutableRefObject<HTMLInputElement | null>
+  categoryNavRef: MutableRefObject<HTMLInputElement | null>
   scrollToTop: () => void
   setCollapseMobileCategories: (collapseMobileCategories: boolean) => void
 }
@@ -447,9 +447,9 @@ export type ContentProps = {
   isMobile: boolean
   signout: () => void
   collapseMobileCategories: boolean
-  categoryNavRef: React.MutableRefObject<HTMLInputElement | null>
+  categoryNavRef: MutableRefObject<HTMLInputElement | null>
   scrollToTop: () => void
-  mobileNavRef: React.MutableRefObject<HTMLInputElement | null>
+  mobileNavRef: MutableRefObject<HTMLInputElement | null>
   setCollapseMobileCategories: (collapseMobileCategories: boolean) => void
   setScaleDescOpen: Dispatch<SetStateAction<boolean>>
   setFirstTimeLogin: Dispatch<SetStateAction<boolean>>


### PR DESCRIPTION
Fjerner `import React from 'react'` nå som vi har oppgradert til React 17, og går over til destructured named imports:

```diff
- import React from 'react'
+ import { useState } from 'react
```

> "... which is the preferred style going into the future."
https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html