### PR TITLE
Adds prop onClose to DeleteOrganizationDialog

### DIFF
--- a/frontend/src/components/SuperAdminPanel/DeleteOrganizationDialog.tsx
+++ b/frontend/src/components/SuperAdminPanel/DeleteOrganizationDialog.tsx
@@ -29,6 +29,7 @@ const DeleteOrganizationDialog: FC<DeleteOrganiationDialogProps> = ({
   return (
     <Dialog
       open={open}
+      onClose={onCancel}
       PaperProps={{
         style: { borderRadius: 30 },
       }}


### PR DESCRIPTION
DeleteOrganizationDialog lukket seg ikke ved escape-knapp eller museklikk utenfor dialogen (som alle andre dialoger gjør)