### PR TITLE
Reset answers if not saved

### DIFF
--- a/frontend/src/components/Content.tsx
+++ b/frontend/src/components/Content.tsx
@@ -354,10 +354,6 @@ const Content = ({ ...props }: ContentProps) => {
     props.isMobile,
   ])
 
-  useEffect(() => {
-    setAnswersBeforeSubmitted(new Map(questionAnswers))
-  }, [questionAnswers])
-
   const { answerHistoryOpen, setAnswerHistoryOpen } = props
   useEffect(() => {
     const fetchUserFormsAndOpenView = async () => {


### PR DESCRIPTION
Når man som bruker forlater et svarskjema i My Answers uten å lagre, burde svarene ikke lagres i frontend. Per nå så kalles `resetAnswers()` i `leaveFormButtonClicked()`, som setter answersBeforeSubmitted-state. Men denne staten endres hver gang questionAnswers endrer seg via en useEffect. Det vil si den "husker" hva svaret var selv om man ikke har lagret.

Løst ved å fjerne det.