### PR TITLE
AddOrganizationDialog: Validate adminEmail does not already exist

### DIFF
--- a/cdk/backend/function/AdminQueries/app.js
+++ b/cdk/backend/function/AdminQueries/app.js
@@ -186,6 +186,25 @@ app.get('/getUser', async (req, res, next) => {
   }
 })
 
+app.get('/getUserExists', async (req, res, next) => {
+  if (!req.query.username) {
+    const err = new Error('username is required')
+    err.statusCode = 400
+    return next(err)
+  }
+
+  try {
+    const response = await getUser(req.query.username)
+    res.status(200).json({ userExists: true, username: req.query.username })
+  } catch (err) {
+    if (err.code == 'UserNotFoundException') {
+      res.status(200).json({ userExists: false, username: req.query.username })
+    } else {
+      next(err)
+    }
+  }
+})
+
 app.get('/listUsers', async (req, res, next) => {
   try {
     let response

--- a/cdk/backend/function/configureNewOrganization/index.py
+++ b/cdk/backend/function/configureNewOrganization/index.py
@@ -43,8 +43,7 @@ def handler(event, context):
         print(f"No admin email provided, organization '{org_id}' is configured without admin user")
     else:
         if user_already_exists(email):
-            print(f"User {email} already exists, adding user to groups")
-            add_user_to_groups(email, org_id)
+            print(f"User {email} already exists, no admin user will be created")
         else:
             create_admin_user(org_id, email)
 

--- a/frontend/src/components/AdminPanel/adminApi.tsx
+++ b/frontend/src/components/AdminPanel/adminApi.tsx
@@ -180,7 +180,26 @@ const listAllUsers = async (limit = 60): Promise<ApiResponse<any[]>> => {
   return { result: allUsers }
 }
 
+const getUser = async (username: string) => {
+  const apiName = 'AdminQueries'
+  const path = '/getUser'
+  const myInit = {
+    queryStringParameters: {
+      username,
+    },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `${(await Auth.currentSession())
+        .getAccessToken()
+        .getJwtToken()}`,
+    },
+  }
+
+  return await API.get(apiName, path, myInit)
+}
+
 export {
+  getUser,
   listAllUsers,
   listAllUsersInOrganization,
   listGroupLeaders,

--- a/frontend/src/components/AdminPanel/adminApi.tsx
+++ b/frontend/src/components/AdminPanel/adminApi.tsx
@@ -180,9 +180,9 @@ const listAllUsers = async (limit = 60): Promise<ApiResponse<any[]>> => {
   return { result: allUsers }
 }
 
-const getUser = async (username: string) => {
+const getUserExists = async (username: string) => {
   const apiName = 'AdminQueries'
-  const path = '/getUser'
+  const path = '/getUserExists'
   const myInit = {
     queryStringParameters: {
       username,
@@ -199,7 +199,7 @@ const getUser = async (username: string) => {
 }
 
 export {
-  getUser,
+  getUserExists,
   listAllUsers,
   listAllUsersInOrganization,
   listGroupLeaders,

--- a/frontend/src/components/SuperAdminPanel/AddOrganizationDialog.tsx
+++ b/frontend/src/components/SuperAdminPanel/AddOrganizationDialog.tsx
@@ -36,7 +36,7 @@ const AddOrganizationDialog: FC<AddOrganizationDialogProps> = ({
   const [organizationAdminEmail, setOrganizationAdminEmail] = useState('')
   const [emailAlreadyExists, setEmailAlreadyExists] = useState<boolean>(false)
   const [isAddingOrganization, setIsAddingOrganization] = useState(false)
-  const [userExistsValidationError, setUserExistsValidationError] =
+  const [emailExistsValidationError, setEmailExistsValidationError] =
     useState<boolean>(false)
 
   const emailRegex = /^[^\s@]+@[^\s@]+$/
@@ -57,7 +57,7 @@ const AddOrganizationDialog: FC<AddOrganizationDialogProps> = ({
 
   const addOrganizationIfEmailDoesNotExist = async () => {
     setIsAddingOrganization(true)
-    setUserExistsValidationError(false)
+    setEmailExistsValidationError(false)
 
     try {
       const res = await getUserExists(organizationAdminEmail)
@@ -69,7 +69,7 @@ const AddOrganizationDialog: FC<AddOrganizationDialogProps> = ({
         setIsAddingOrganization(false)
       }
     } catch (e) {
-      setUserExistsValidationError(true)
+      setEmailExistsValidationError(true)
       setIsAddingOrganization(false)
     }
   }
@@ -163,12 +163,12 @@ const AddOrganizationDialog: FC<AddOrganizationDialogProps> = ({
           onChange={(e: any) => {
             setOrganizationAdminEmail(e.target.value)
             setEmailAlreadyExists(false)
-            setUserExistsValidationError(false)
+            setEmailExistsValidationError(false)
           }}
         />
       </DialogTitle>
-      {userExistsValidationError && (
-        <p style={{ display: 'flex', justifyContent: 'center' }}>
+      {emailExistsValidationError && (
+        <p style={{ textAlign: 'center' }}>
           {t('errorOccured') +
             t(
               'superAdmin.editOrganizations.couldNotValidateIfAUserWithTheEmailAlreadyExists'

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -255,7 +255,8 @@ export const English: LanguageSchema = {
         addNewOrganization: 'Add new organization',
         idCantBeEmptyOrContainZero: "ID can't be empty or contain '0'.",
         identifierAttributeCantBeEmpty: "Identifier attribute can't be empty.",
-        adminEmailIsInvalid: 'Admin email is invalid.'
+        adminEmailIsInvalid: 'Admin email is invalid.',
+        thereAlreadyExistsAUserWithTheEmail: "There already exists a user with the email '{{email}}'.",
       },
       editSuperAdministrators: {
         description: 'On this page you can add and remove super-administrators.',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -257,6 +257,7 @@ export const English: LanguageSchema = {
         identifierAttributeCantBeEmpty: "Identifier attribute can't be empty.",
         adminEmailIsInvalid: 'Admin email is invalid.',
         thereAlreadyExistsAUserWithTheEmail: "There already exists a user with the email '{{email}}'.",
+        couldNotValidateIfAUserWithTheEmailAlreadyExists: 'Could not validate if a user with the email already exists.',
       },
       editSuperAdministrators: {
         description: 'On this page you can add and remove super-administrators.',

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -257,6 +257,7 @@ export const Norwegian: LanguageSchema = {
         identifierAttributeCantBeEmpty: 'Identifier attribute kan ikke være tom.',
         adminEmailIsInvalid: 'Admin e-post er ugyldig.',
         thereAlreadyExistsAUserWithTheEmail: "Det finnes allerede en bruker med mailen '{{email}}'.",
+        couldNotValidateIfAUserWithTheEmailAlreadyExists: 'Kunne ikke validere om en bruker med e-posten allerede finnes.',
       },
       editSuperAdministrators: {
         description: 'På denne siden kan du legge til og fjerne super-administratorer.',

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -256,6 +256,7 @@ export const Norwegian: LanguageSchema = {
         idCantBeEmptyOrContainZero: "ID kan ikke være tom eller inneholde '0'.",
         identifierAttributeCantBeEmpty: 'Identifier attribute kan ikke være tom.',
         adminEmailIsInvalid: 'Admin e-post er ugyldig.',
+        thereAlreadyExistsAUserWithTheEmail: "Det finnes allerede en bruker med mailen '{{email}}'.",
       },
       editSuperAdministrators: {
         description: 'På denne siden kan du legge til og fjerne super-administratorer.',

--- a/frontend/src/i18n/schema.ts
+++ b/frontend/src/i18n/schema.ts
@@ -254,6 +254,7 @@ export type LanguageSchema = {
         idCantBeEmptyOrContainZero: string
         identifierAttributeCantBeEmpty: string
         adminEmailIsInvalid: string
+        thereAlreadyExistsAUserWithTheEmail: string
       }
       editSuperAdministrators: {
         description: string

--- a/frontend/src/i18n/schema.ts
+++ b/frontend/src/i18n/schema.ts
@@ -255,6 +255,7 @@ export type LanguageSchema = {
         identifierAttributeCantBeEmpty: string
         adminEmailIsInvalid: string
         thereAlreadyExistsAUserWithTheEmail: string
+        couldNotValidateIfAUserWithTheEmailAlreadyExists: string
       }
       editSuperAdministrators: {
         description: string


### PR DESCRIPTION
* Nytt AdminQueries-endepunkt `/getUserExists`, for å sjekke om en bruker allerede finnes.
* `AddOrganizationDialog` validerer at det ikke allerede finnes en bruker med oppgitt e-post før ny org kan legges til. Feedback gis i dialog så man slipper å skrive inn alt på nytt.
* `configureNewOrganizationLambda` legger ikke lengre til eksisterende bruker i organisasjonen som opprettes.