### PR TITLE
Removes 'update' from  edit organizations description

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -247,7 +247,7 @@ export const English: LanguageSchema = {
       identifierAttribute: 'Identifier Attribute',
       areYouSureYouWantToRemoveNameFromRoleAtOrganization: 'Are you sure you want to remove {{name}} from the {{role}} at {{organization}}?',
       editOrganizations: {
-        description: 'On this page you can add, remove and update organizations.',
+        description: 'On this page you can add and remove organizations.',
         id: 'ID',
         adminEmail: 'Admin Email',
         addOrganization: 'Add organization',

--- a/frontend/src/i18n/locales/no.ts
+++ b/frontend/src/i18n/locales/no.ts
@@ -247,7 +247,7 @@ export const Norwegian: LanguageSchema = {
       identifierAttribute: 'Identifikatorattributt',
       areYouSureYouWantToRemoveNameFromRoleAtOrganization: 'Er du sikker på at du har lyst til å fjerne {{name}} fra {{role}} i {{organization}}?',
       editOrganizations: {
-        description: 'På denne siden kan du legge til, fjerne og oppdatere organisasjoner.',
+        description: 'På denne siden kan du legge til og fjerne organisasjoner.',
         id: 'ID',
         adminEmail: 'Admin E-post',
         addOrganization: 'Legg til organisasjon',


### PR DESCRIPTION
Det ble poengtert at man ikke kan oppdatere organisasjoner - som jo er riktig.