### PR TITLE
Turn off new default blockPublicAccess settings

### DIFF
--- a/frontend-cdk/lib/KompetanseFrontendStack.ts
+++ b/frontend-cdk/lib/KompetanseFrontendStack.ts
@@ -20,7 +20,8 @@ export class KompetanseFrontendStack extends Stack {
         blockPublicPolicy: false,
         ignorePublicAcls: false,
         restrictPublicBuckets: false
-      }
+      },
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER
     });
 
     const s3Origin = new origins.S3Origin(websiteBucket);

--- a/frontend-cdk/lib/KompetanseFrontendStack.ts
+++ b/frontend-cdk/lib/KompetanseFrontendStack.ts
@@ -15,7 +15,12 @@ export class KompetanseFrontendStack extends Stack {
     const websiteBucket = new s3.Bucket(this, 'KompetanseHostingBucket', {
       websiteIndexDocument: 'index.html',
       publicReadAccess: true,
-
+      blockPublicAccess: {
+        blockPublicAcls: false,
+        blockPublicPolicy: false,
+        ignorePublicAcls: false,
+        restrictPublicBuckets: false
+      }
     });
 
     const s3Origin = new origins.S3Origin(websiteBucket);


### PR DESCRIPTION
Skrur av alle `blockPublicAccess`-instillinger på `KompetanseHostingBucket` etter [AWS-oppdatering](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/)
Innstilligene og resulterende bucket policy blir nå lik som den har vært (allow s3:getObject for *).

https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html#access-control-block-public-access-options

closes #191 