### PR TITLE
GHA deploy using OIDC and IAM role

### DIFF
--- a/.github/workflows/callable-deploy.yml
+++ b/.github/workflows/callable-deploy.yml
@@ -16,11 +16,9 @@ on:
         type: boolean
         default: true
     secrets:
-      aws_access_key_id:
+      AWS_DEPLOY_ROLE:
         required: true
-      aws_secret_access_key:
-        required: true
-      azure:
+      AZURE:
         required: true
       SLACK_DEPLOY_WEBHOOK_URL:
         required: true
@@ -29,6 +27,9 @@ jobs:
   deploy:
     name: Deploy ${{ inputs.aws_environment }}
     runs-on: ubuntu-latest
+    permissions: # Needed to interact with GitHub's OIDC Token endpoint
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -38,8 +39,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE }}
           aws-region: ${{ inputs.aws_region }}
 
       - name: Install packages
@@ -54,7 +54,7 @@ jobs:
           --require-approval never \
           --outputs-file outputs.json \
           --context ENV=${{ inputs.aws_environment }} \
-          --context AZURE=${{ secrets.azure }} \
+          --context AZURE=${{ secrets.AZURE }} \
           --context EXCEL=${{ inputs.excel }}
 
       - name: Prepare frontend ${{ inputs.aws_environment }} deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - github-actions-deploy-with-role # TODO: remove
   workflow_dispatch:
     inputs:
       aws_environment:
@@ -54,7 +53,7 @@ jobs:
 
   deploy_dev_on_push_main:
     needs: check_files
-    if: github.event_name == 'push' # && needs.check_files.outputs.any_modified == 'true' TODO: remove #
+    if: github.event_name == 'push' && needs.check_files.outputs.any_modified == 'true'
     name: Deploy dev on push to main
     permissions: # Needed to interact with GitHub's OIDC Token endpoint
       id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - github-actions-deploy-with-role # TODO: remove
   workflow_dispatch:
     inputs:
       aws_environment:
@@ -38,7 +39,8 @@ jobs:
               *.sh
               scripts/*
               .github/dependabot.yml
-              .github/workflows/frontend-eslint-prettier.yml
+              .github/workflows/code-analysis.yml
+              .github/workflows/test.yml
               .gitignore
               .github/ISSUE_TEMPLATE/*
 
@@ -52,27 +54,31 @@ jobs:
 
   deploy_dev_on_push_main:
     needs: check_files
-    if: github.event_name == 'push' && needs.check_files.outputs.any_modified == 'true'
+    if: github.event_name == 'push' # && needs.check_files.outputs.any_modified == 'true' TODO: remove #
     name: Deploy dev on push to main
+    permissions: # Needed to interact with GitHub's OIDC Token endpoint
+      id-token: write
+      contents: read
     uses: ./.github/workflows/callable-deploy.yml
     with:
       aws_environment: dev
       deploy_backend_only: false
     secrets:
-      aws_access_key_id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY}}
-      azure: ${{ secrets.DEV_AZURE }}
+      AWS_DEPLOY_ROLE: ${{ secrets.DEV_AWS_DEPLOY_ROLE }}
+      AZURE: ${{ secrets.DEV_AZURE }}
       SLACK_DEPLOY_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
 
   deploy_on_workflow_dispatch:
     if: github.event_name == 'workflow_dispatch'
     name: Deploy on dispatch
+    permissions: # Needed to interact with GitHub's OIDC Token endpoint
+      id-token: write
+      contents: read
     uses: ./.github/workflows/callable-deploy.yml
     with:
       aws_environment: ${{ inputs.aws_environment }}
       deploy_backend_only: ${{ inputs.deploy_backend_only }}
     secrets:
-      aws_access_key_id: ${{ inputs.aws_environment == 'prod' && secrets.PROD_AWS_ACCESS_KEY_ID || secrets.DEV_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ inputs.aws_environment == 'prod' && secrets.PROD_AWS_SECRET_ACCESS_KEY || secrets.DEV_AWS_SECRET_ACCESS_KEY}}
-      azure: ${{ inputs.aws_environment == 'prod' && secrets.PROD_AZURE || secrets.DEV_AZURE }}
+      AWS_DEPLOY_ROLE: ${{ inputs.aws_environment == 'prod' && secrets.PROD_AWS_DEPLOY_ROLE || secrets.DEV_AWS_DEPLOY_ROLE }}
+      AZURE: ${{ inputs.aws_environment == 'prod' && secrets.PROD_AZURE || secrets.DEV_AZURE }}
       SLACK_DEPLOY_WEBHOOK_URL: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}


### PR DESCRIPTION
Nåværende deploy-oppsett bruker IAM user og ikke-utløpende credentials lagret som secrets.
Med disse endringene bruker vi IAM role og GitHubs OIDC provider, som er anbefalt måte å deploye på.

AWS dev og prod:
* Opprettet IAM identity provider
* Opprettet IAM role `github-actions-deploy-role` med trust relationship som whitelister main-branchen i dette repoet

GitHub:
* Lagt til secrets `DEV_AWS_DEPLOY_ROLE` og `PROD_AWS_DEPLOY_ROLE` med ARN til IAM-rollen som verdi.
  MÅ ikke være secrets pga. nåværende trust relationship, men sikkert greit å være på den sikre siden.
* Deploy-workflow bruker ARN til IAM role for å deploye

https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services

closes #190 