### PR TITLE
Add emoji, remove dash for slackbot deploy message

### DIFF
--- a/.github/workflows/callable-deploy.yml
+++ b/.github/workflows/callable-deploy.yml
@@ -86,6 +86,6 @@ jobs:
           SLACK_COLOR: ${{ needs.deploy.result }}
           SLACK_USERNAME: Kompetansekartlegging deploy bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_DEPLOY_WEBHOOK_URL }}
-          SLACK_MESSAGE: "[Deploy to ${{inputs.aws_environment}}] - ${{ github.event.head_commit.message }}"
+          SLACK_MESSAGE: ":${{inputs.aws_environment}}: [Deploy to ${{inputs.aws_environment}}] ${{ github.event.head_commit.message }}"
           MSG_MINIMAL: event,commit
           SLACK_FOOTER:


### PR DESCRIPTION
* Adds knowit-slack emojis :dev: and :prod: in front of message for some ✨ 
* Removes dash so that manual deploys to prod don't show trailing dash, e.g. `[Deploy to prod] -`
