### PR TITLE
Improve test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Additionally, deployment can be triggered through the dispatchable workflow "`De
 ### Linting & Code formatting
 ESLint and Prettier is configured for the frontend code using recommended rules. GitHub Actions analyzes the code when PRs towards the main branch are opened.
 
+### Test
+Tests run on every pull request towards the main branch.
+
 ### Slack Notifications
 When deploying to both the dev and production environments, a bot will post to a channel using [Slack Apps](https://api.slack.com/) and the [Slack Notify](https://github.com/rtCamp/action-slack-notify) action.
 

--- a/cdk/install.sh
+++ b/cdk/install.sh
@@ -4,3 +4,13 @@ cd backend/presignup && npm install
 cd ../function/AdminQueries && npm install
 cd ../createUserformBatch && npm install
 cd ../externalAPI && npm install
+
+# Install python packages
+cd ../..
+requirement_files=$(find . -name 'requirements.txt')
+for requirement_file in $requirement_files;
+do
+    if [[ $requirement_file != *'node_modules'* && $requirement_file != *'cdk.out'* ]]; then
+        pip install -q -r $requirement_file
+    fi
+done

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -5164,6 +5164,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/amplify-cli-core/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5177,6 +5179,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/amplify-cli-core/node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5244,6 +5248,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/ansi-styles/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5285,6 +5291,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/ast-types/node_modules/tslib": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "inBundle": true,
       "license": "0BSD"
     },
@@ -5427,6 +5435,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/color-convert/node_modules/color-name": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "inBundle": true,
       "license": "MIT"
     },
@@ -5530,6 +5540,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "inBundle": true,
       "license": "MIT"
     },
@@ -5562,6 +5574,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/degenerator/node_modules/escodegen": {
       "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5616,6 +5630,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/dir-glob/node_modules/path-type": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5743,6 +5759,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/fastq": {
       "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5823,6 +5841,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/ftp/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5872,6 +5892,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/get-uri/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6068,6 +6090,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/graphql-relational-schema-transformer/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6116,6 +6140,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/graphql-transformer-core/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6355,7 +6381,7 @@
     "node_modules/cdk-appsync-transformer/node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "inBundle": true,
       "license": "ISC"
     },
@@ -6618,6 +6644,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/optionator/node_modules/levn": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6737,6 +6765,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7028,6 +7058,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -7131,6 +7163,8 @@
     },
     "node_modules/cdk-appsync-transformer/node_modules/ts-node/node_modules/diff": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/cdk/test.sh
+++ b/cdk/test.sh
@@ -20,6 +20,10 @@ fi
 
 echo "Running python tests..."
 pytest
+if [ $? != 0 ]
+then
+    exit $?
+fi
 
 dynamo_container_name="dynamodb-local-container"
 cognito_container_name="cognito-local-container"

--- a/cdk/test.sh
+++ b/cdk/test.sh
@@ -1,4 +1,26 @@
 #!/bin/bash
+if [[ "$1" == "install-dependencies" ]]
+then
+    echo "Installing cdk dependencies..."
+    npm install -s
+
+    echo "Installing cdk/backend/function/AdminQueries dependencies..."
+    cd backend/function/AdminQueries && npm install -s
+    cd ../../..
+
+    echo "Installing python dependencies..."
+    requirement_files=$(find . -name 'requirements.txt')
+    for requirement_file in $requirement_files;
+    do
+        if [[ $requirement_file != *'node_modules'* && $requirement_file != *'cdk.out'* ]]; then
+            pip install -q -r $requirement_file
+        fi
+    done
+fi
+
+echo "Running python tests..."
+pytest
+
 dynamo_container_name="dynamodb-local-container"
 cognito_container_name="cognito-local-container"
 

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -3642,6 +3642,8 @@ escape-string-regexp@^4.0.0:
 
 escodegen@^1.8.1:
   version "1.14.3"
+  resolved "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz"
+  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
   dependencies:
     esprima "^4.0.1"
     estraverse "^4.2.0"
@@ -4038,6 +4040,8 @@ formidable@^2.1.2:
 
 fs-extra@^8.1.0:
   version "8.1.0"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
@@ -5352,6 +5356,8 @@ levn@^0.4.1:
 
 levn@~0.3.0:
   version "0.3.0"
+  resolved "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
@@ -6073,6 +6079,8 @@ readable-stream@^3.4.0:
 
 readable-stream@1.1.x:
   version "1.1.14"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -6697,6 +6705,8 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.4
 
 tslib@^2.0.1:
   version "2.3.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@~2.5.0:
   version "2.5.0"

--- a/test.sh
+++ b/test.sh
@@ -1,20 +1,3 @@
 #!/bin/bash
-echo "Installing python dependencies..."
-requirement_files=$(find . -name 'requirements.txt')
-for requirement_file in $requirement_files;
-do
-    if [[ $requirement_file != *'node_modules'* && $requirement_file != *'cdk.out'* ]]; then
-        pip install -q -r $requirement_file
-    fi
-done
-
-echo "Running python tests..."
-pytest
-
-echo "Installing ./cdk dependencies..."
-cd cdk && npm install -s
-echo "Installing ./cdk/backend/function/AdminQueries dependencies..."
-cd backend/function/AdminQueries && npm install -s
-
 echo "Running ./cdk tests..."
-cd ../../../ && npm run test
+cd cdk && ./test.sh install-dependencies && cd ..


### PR DESCRIPTION
Forenkler test-scriptet på rotnivå ved å flytte dependency-installasjon til det cdk-spesifikke test-scriptet.

I cdk test-scriptet er dependency-installasjonen valgfri, for å spare tid når man utvikler tester og stadig kjører dem (alt blir jo installert lokalt når man kjører ./install-scriptet).

Fikser også at python-testene i cdk-mappa ikke ble kjørt da man kjørte cdk test-scriptet.